### PR TITLE
Add Anthropic skills as git submodule

### DIFF
--- a/.claude/skills/frontend-design
+++ b/.claude/skills/frontend-design
@@ -1,0 +1,1 @@
+../../submodules/skills/skills/frontend-design

--- a/.claude/skills/web-artifacts-builder
+++ b/.claude/skills/web-artifacts-builder
@@ -1,0 +1,1 @@
+../../submodules/skills/skills/web-artifacts-builder

--- a/.claude/skills/webapp-testing
+++ b/.claude/skills/webapp-testing
@@ -1,0 +1,1 @@
+../../submodules/skills/skills/webapp-testing

--- a/.codex/skills/frontend-design
+++ b/.codex/skills/frontend-design
@@ -1,0 +1,1 @@
+../../submodules/skills/skills/frontend-design

--- a/.codex/skills/web-artifacts-builder
+++ b/.codex/skills/web-artifacts-builder
@@ -1,0 +1,1 @@
+../../submodules/skills/skills/web-artifacts-builder

--- a/.codex/skills/webapp-testing
+++ b/.codex/skills/webapp-testing
@@ -1,0 +1,1 @@
+../../submodules/skills/skills/webapp-testing

--- a/.github/skills/frontend-design
+++ b/.github/skills/frontend-design
@@ -1,0 +1,1 @@
+../../submodules/skills/skills/frontend-design

--- a/.github/skills/web-artifacts-builder
+++ b/.github/skills/web-artifacts-builder
@@ -1,0 +1,1 @@
+../../submodules/skills/skills/web-artifacts-builder

--- a/.github/skills/webapp-testing
+++ b/.github/skills/webapp-testing
@@ -1,0 +1,1 @@
+../../submodules/skills/skills/webapp-testing

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "submodules/skills"]
+	path = submodules/skills
+	url = https://github.com/anthropics/skills.git


### PR DESCRIPTION
## Summary
- Adds the Anthropic skills repository as a git submodule under `submodules/skills`
- Enables integration with official Anthropic skills

## Test plan
- [ ] Verify submodule was added correctly: `git submodule status`
- [ ] Verify submodule can be initialized: `git submodule init && git submodule update`
- [ ] Check that skills are accessible in the submodules directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)