### PR TITLE
Add skill documentation and update indexes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -119,6 +119,9 @@ Shared `skills/` directory (symlinked into `.claude/skills`, `.codex/skills`, `.
 - **OpenAI Codex CLI**: `codex-ask`, `codex-exec`, `codex-review`, `codex-search`
 - **GitHub Copilot CLI**: `copilot-ask`, `copilot-exec`, `copilot-review`, `copilot-search`
 - **Gemini CLI**: `gemini-ask`, `gemini-exec`, `gemini-review`, `gemini-search`
+- **Git Workflows**: `clean-gone-branches`, `commit`, `commit-push-pr`
+- **Code Quality**: `code-review`, `code-simplifier`
+- **Skill Management**: `claude-agent-converter`, `claude-command-converter`
 
 ## Validation
 

--- a/README.md
+++ b/README.md
@@ -60,6 +60,22 @@ All skills are located in `skills/` and symlinked into runtime-specific director
 - `gemini-review` - Perform code reviews (read-only)
 - `gemini-search` - Search the web for current information (read-only)
 
+### Git Workflows
+
+- `clean-gone-branches` - Clean up local branches marked as [gone] and their worktrees
+- `commit` - Create a git commit with an appropriate message
+- `commit-push-pr` - Commit, push, and open a pull request
+
+### Code Quality
+
+- `code-review` - Comprehensive multi-agent code review for pull requests
+- `code-simplifier` - Simplify and refine code for clarity and maintainability
+
+### Skill Management
+
+- `claude-agent-converter` - Convert Claude Code agents to portable skills
+- `claude-command-converter` - Convert Claude Code commands to portable skills
+
 ## Agents
 
 Agents are located in `.claude/agents/` and provide unified interfaces for each CLI tool.

--- a/skills/clean-gone-branches/SKILL.md
+++ b/skills/clean-gone-branches/SKILL.md
@@ -1,0 +1,60 @@
+---
+name: clean-gone-branches
+description: Clean up all git branches marked as [gone] (branches deleted on the remote but still existing locally), including removing associated worktrees.
+---
+
+# Clean Gone Branches Skill
+
+Remove stale local branches that have been deleted from the remote repository, along with any associated worktrees.
+
+## When to Use
+
+- After merging and deleting remote branches, to clean up local tracking branches.
+- When `git branch -v` shows branches marked as `[gone]`.
+- Periodic local repository maintenance.
+
+## Agent Compatibility
+
+This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, GitHub Copilot CLI, or Gemini CLI.
+
+## Inputs
+
+- None required. The skill operates on the current git repository.
+
+## Workflow
+
+1. **List branches** to identify any with `[gone]` status:
+
+   ```bash
+   git branch -v
+   ```
+
+   Branches with a `+` prefix have associated worktrees and must have their worktrees removed before deletion.
+
+2. **List worktrees** that may need removal for `[gone]` branches:
+
+   ```bash
+   git worktree list
+   ```
+
+3. **Remove worktrees and delete `[gone]` branches**:
+
+   ```bash
+   git branch -v | grep '\[gone\]' | sed 's/^[+* ]//' | awk '{print $1}' | while read branch; do
+     echo "Processing branch: $branch"
+     worktree=$(git worktree list | grep "\\[$branch\\]" | awk '{print $1}')
+     if [ ! -z "$worktree" ] && [ "$worktree" != "$(git rev-parse --show-toplevel)" ]; then
+       echo "  Removing worktree: $worktree"
+       git worktree remove --force "$worktree"
+     fi
+     echo "  Deleting branch: $branch"
+     git branch -D "$branch"
+   done
+   ```
+
+4. **Report results**: List which worktrees and branches were removed. If no branches are marked as `[gone]`, report that no cleanup was needed.
+
+## Outputs
+
+- Console output listing removed worktrees and deleted branches.
+- If no `[gone]` branches exist, a message indicating no cleanup was needed.

--- a/skills/commit-push-pr/SKILL.md
+++ b/skills/commit-push-pr/SKILL.md
@@ -1,0 +1,59 @@
+---
+name: commit-push-pr
+description: Commit staged and unstaged changes, push the branch to origin, and open a pull request using the GitHub CLI.
+---
+
+# Commit, Push, and PR Skill
+
+Create a commit from current changes, push to a remote branch, and open a pull request in a single workflow.
+
+## When to Use
+
+- After completing a feature or fix and wanting to open a PR in one step.
+- When all changes are ready to commit, push, and submit for review.
+
+## Agent Compatibility
+
+This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, GitHub Copilot CLI, or Gemini CLI.
+
+## Inputs
+
+- Current repository with uncommitted changes (staged or unstaged).
+
+If there are no changes to commit, report that and stop.
+
+## Workflow
+
+1. **Gather context** by running these commands in parallel:
+
+   ```bash
+   git status
+   git diff HEAD
+   git branch --show-current
+   ```
+
+2. **Create a new branch** if currently on `main` (or the repository's default branch). Use an appropriate branch name based on the changes.
+
+3. **Stage and commit** all relevant changes with a concise, descriptive commit message summarizing the changes.
+
+4. **Push the branch** to origin:
+
+   ```bash
+   git push -u origin <branch-name>
+   ```
+
+5. **Create a pull request** using the GitHub CLI:
+
+   ```bash
+   gh pr create --title "<title>" --body "<description>"
+   ```
+
+   Include a clear title and summary of changes in the PR body.
+
+All steps should be executed as efficiently as possible, combining independent operations.
+
+## Outputs
+
+- A new git commit on the current or newly created branch.
+- The branch pushed to origin.
+- A pull request created on GitHub (URL printed to console).

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -1,0 +1,50 @@
+---
+name: commit
+description: Create a git commit from current staged and unstaged changes with an appropriate commit message.
+---
+
+# Commit Skill
+
+Stage and commit current changes with a concise, well-formed commit message based on the diff and recent commit history.
+
+## When to Use
+
+- After completing a change and wanting to commit it.
+- When all modifications are ready to be captured in a single commit.
+
+## Agent Compatibility
+
+This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, GitHub Copilot CLI, or Gemini CLI.
+
+## Inputs
+
+- Current repository with uncommitted changes (staged or unstaged).
+
+If there are no changes to commit, report that and stop.
+
+## Workflow
+
+1. **Gather context** by running these commands in parallel:
+
+   ```bash
+   git status
+   git diff HEAD
+   git branch --show-current
+   git log --oneline -10
+   ```
+
+2. **Analyze changes** from the diff output to understand what was modified and why.
+
+3. **Stage relevant files** using `git add` for the appropriate files.
+
+4. **Create a commit** with a concise, descriptive message that:
+   - Follows the repository's existing commit message style (based on recent commits).
+   - Summarizes the nature of the change (new feature, bug fix, refactor, etc.).
+   - Uses imperative mood and sentence case.
+
+Stage and commit should be executed as efficiently as possible in a single step.
+
+## Outputs
+
+- A new git commit on the current branch.
+- Console output confirming the commit was created.


### PR DESCRIPTION
## Summary
- Add SKILL.md documentation for clean-gone-branches, commit, and commit-push-pr skills
- Update AGENTS.md and README.md to index new skills across Git Workflows, Code Quality, and Skill Management categories

## Changes
- `skills/clean-gone-branches/SKILL.md` - Clean up local branches marked as [gone]
- `skills/commit/SKILL.md` - Create a git commit with appropriate message
- `skills/commit-push-pr/SKILL.md` - Commit, push, and open a PR in one workflow
- Updated skill listings in AGENTS.md and README.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)