### PR TITLE
Add PR feedback triage skill

### DIFF
--- a/.claude/agents/codex.md
+++ b/.claude/agents/codex.md
@@ -1,6 +1,6 @@
 ---
 name: codex
-description: OpenAI Codex CLI integration agent for code analysis, development, review, and research. MUST BE USED when a task matches these modes. Supports ask (read-only Q&A), exec (code generation/modification), review (code review), and search (web research).
+description: Codex CLI integration agent for code analysis, development, review, and research. MUST BE USED when a task matches these modes. Supports ask (read-only Q&A), exec (code generation/modification), review (code review), and search (web research).
 tools: Read, Write, Edit, Grep, Glob, Bash, LSP, WebFetch, WebSearch
 model: inherit
 skills: codex-cli
@@ -8,7 +8,7 @@ skills: codex-cli
 
 # Codex Agent
 
-You are a specialized agent that integrates OpenAI Codex CLI capabilities for autonomous development tasks. You operate in one of four modes based on the user's needs:
+You are a specialized agent that integrates Codex CLI capabilities for autonomous development tasks. You operate in one of four modes based on the user's needs:
 
 - **Ask Mode** - Answer questions about code (read-only)
 - **Exec Mode** - Generate, modify, and refactor code

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,6 +8,8 @@ on:
       - opened
       - synchronize
       - reopened
+permissions:
+  contents: read
 jobs:
   dependabot-auto-merge:
     if: >

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 ## Repository Purpose
 
-This is a single-source skill library shared across AI coding runtimes (Claude Code, OpenAI Codex CLI). The `skills/` directory is the authoritative source of truth; runtime-specific directories reference it via symlinks.
+This is a single-source skill library shared across AI coding runtimes (Claude Code, Codex CLI). The `skills/` directory is the authoritative source of truth; runtime-specific directories reference it via symlinks.
 
 ## Architecture
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ All skills are located in `skills/` and surfaced through shared discovery or run
 
 - `code-review` - Comprehensive multi-agent code review for pull requests
 - `code-simplifier` - Simplify and refine code for clarity and maintainability
+- `pr-review-comment-triage` - Triage and resolve pull request review comments
 - `security-guidance` - Security-focused review of code changes, diffs, commits, and pull requests
 
 ### Skill Management

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Agent skills for AI coders
 Single-source, reusable skills and agent prompts shared across AI coding runtimes. The `skills/` directory is the source of truth and is referenced by runtime-specific integrations:
 
 - **Claude Code** — Unified `claude-code` skill in `skills/claude-code/`, plus agents in `.claude/agents/`; skills via `.claude/skills -> ../skills`
-- **OpenAI Codex CLI** — Unified `codex-cli` skill in `skills/codex-cli/`, used by `.claude/agents/codex.md`
+- **Codex CLI** — Unified `codex-cli` skill in `skills/codex-cli/`, used by `.claude/agents/codex.md`
 
 Each skill directory contains a `SKILL.md` that documents prerequisites and invocation.
 
@@ -33,9 +33,9 @@ All skills are located in `skills/` and surfaced through shared discovery or run
 
 - `claude-code` - Unified Claude Code skill for ask, exec, review, and search workflows
 
-### OpenAI Codex CLI Integration
+### Codex CLI Integration
 
-- `codex-cli` - Unified OpenAI Codex CLI skill for ask, exec, review, and search workflows
+- `codex-cli` - Unified Codex CLI skill for ask, exec, review, and search workflows
 
 ### Git Workflows
 
@@ -93,7 +93,7 @@ Install and authenticate the required CLI tools before running skills:
   - Install: <https://docs.anthropic.com/en/docs/claude-code>
   - Auth: Follow CLI onboarding flow
 
-- **OpenAI Codex CLI** - For the `codex-cli` skill and `.claude/agents/codex.md`
+- **Codex CLI** - For the `codex-cli` skill and `.claude/agents/codex.md`
   - Install: <https://github.com/openai/codex>
   - Auth: ChatGPT subscription or API key in `~/.codex/config.toml`
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ All skills are located in `skills/` and surfaced through shared discovery or run
 
 - `code-review` - Comprehensive multi-agent code review for pull requests
 - `code-simplifier` - Simplify and refine code for clarity and maintainability
-- `pr-review-comment-triage` - Triage and resolve pull request review comments
+- `pr-feedback-triage` - Triage and resolve pull request review feedback
 - `security-guidance` - Security-focused review of code changes, diffs, commits, and pull requests
 
 ### Skill Management

--- a/skills/claude-agent-converter/SKILL.md
+++ b/skills/claude-agent-converter/SKILL.md
@@ -12,7 +12,7 @@ Convert Claude Code subagents to standard Agent Skills format for portability ac
 - Migrating existing `.claude/agents/*.md` subagent files to `skills/*/SKILL.md` format.
 - Extracting reusable workflows from subagent definitions.
 - Creating portable skills from Claude Code-specific agents.
-- Standardizing agent definitions for use with Claude Code, Codex CLI, GitHub Copilot, and other runtimes.
+- Standardizing agent definitions for use with Claude Code, Codex CLI, Cursor CLI, and other runtimes.
 
 ## Inputs
 

--- a/skills/claude-command-converter/SKILL.md
+++ b/skills/claude-command-converter/SKILL.md
@@ -11,7 +11,7 @@ Convert Claude Code commands to standard Agent Skills format for portability acr
 
 - Migrating existing `.claude/commands/*.md` files to `skills/*/SKILL.md` format.
 - Creating portable skills from Claude Code-specific commands.
-- Standardizing command definitions for use with Claude Code, Codex CLI, GitHub Copilot, and other runtimes.
+- Standardizing command definitions for use with Claude Code, Codex CLI, Cursor CLI, and other runtimes.
 
 ## Inputs
 

--- a/skills/clean-gone-branches/SKILL.md
+++ b/skills/clean-gone-branches/SKILL.md
@@ -15,7 +15,7 @@ Remove stale local branches that have been deleted from the remote repository, a
 
 ## Agent Compatibility
 
-This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, GitHub Copilot CLI, or Gemini CLI.
+This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, or Cursor CLI.
 
 ## Inputs
 

--- a/skills/clean-gone-branches/SKILL.md
+++ b/skills/clean-gone-branches/SKILL.md
@@ -15,7 +15,7 @@ Remove stale local branches that have been deleted from the remote repository, a
 
 ## Agent Compatibility
 
-This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, or Cursor CLI.
+This skill is tool-agnostic and can be executed by Claude Code, Codex CLI, or Cursor CLI.
 
 ## Inputs
 

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -15,7 +15,7 @@ Provide thorough, multi-agent code review for pull requests with high-confidence
 
 ## Agent Compatibility
 
-This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, GitHub Copilot CLI, or Gemini CLI.
+This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, or Cursor CLI.
 When posting the PR comment, replace `<agent-name>` in the output template with the active agent name.
 
 ## Inputs

--- a/skills/code-review/SKILL.md
+++ b/skills/code-review/SKILL.md
@@ -15,7 +15,7 @@ Provide thorough, multi-agent code review for pull requests with high-confidence
 
 ## Agent Compatibility
 
-This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, or Cursor CLI.
+This skill is tool-agnostic and can be executed by Claude Code, Codex CLI, or Cursor CLI.
 When posting the PR comment, replace `<agent-name>` in the output template with the active agent name.
 
 ## Inputs

--- a/skills/codex-cli/SKILL.md
+++ b/skills/codex-cli/SKILL.md
@@ -1,12 +1,12 @@
 ---
 name: codex-cli
-description: Use OpenAI Codex CLI whenever the user wants Codex-powered help with a repository, including understanding code, generating or modifying code, reviewing changes, or researching current documentation and best practices. This unified skill covers ask, exec, review, and search modes, so use it even when the request spans multiple phases such as research -> implementation -> review. Requires Codex CLI installed; native web research uses `codex --search`, with `WebFetch` or `WebSearch` as verification or fallback when helpful.
+description: Use Codex CLI whenever the user wants Codex-powered help with a repository, including understanding code, generating or modifying code, reviewing changes, or researching current documentation and best practices. This unified skill covers ask, exec, review, and search modes, so use it even when the request spans multiple phases such as research -> implementation -> review. Requires Codex CLI installed; native web research uses `codex --search`, with `WebFetch` or `WebSearch` as verification or fallback when helpful.
 allowed-tools: Bash, Read, Write, Edit, Grep, Glob, WebFetch, WebSearch
 ---
 
 # Codex CLI Skill
 
-Use OpenAI Codex CLI as a unified interface for Codex-assisted analysis, execution, review, and research. Start by selecting the right mode, gather the right context, then run Codex with a prompt that matches the user's goal.
+Use Codex CLI as a unified interface for Codex-assisted analysis, execution, review, and research. Start by selecting the right mode, gather the right context, then run Codex with a prompt that matches the user's goal.
 
 ## Mode Selection
 
@@ -361,4 +361,4 @@ Codex CLI is especially helpful when the task benefits from:
 
 ---
 
-**Remember**: Use OpenAI Codex CLI as the primary engine for Codex-assisted work. Pick the correct mode first, gather context before prompting, and always verify the result before handing it back.
+**Remember**: Use Codex CLI as the primary engine for Codex-assisted work. Pick the correct mode first, gather context before prompting, and always verify the result before handing it back.

--- a/skills/commit-push-pr/SKILL.md
+++ b/skills/commit-push-pr/SKILL.md
@@ -14,7 +14,7 @@ Create a commit from current changes, push to a remote branch, and open a pull r
 
 ## Agent Compatibility
 
-This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, GitHub Copilot CLI, or Gemini CLI.
+This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, or Cursor CLI.
 
 ## Inputs
 

--- a/skills/commit-push-pr/SKILL.md
+++ b/skills/commit-push-pr/SKILL.md
@@ -14,7 +14,7 @@ Create a commit from current changes, push to a remote branch, and open a pull r
 
 ## Agent Compatibility
 
-This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, or Cursor CLI.
+This skill is tool-agnostic and can be executed by Claude Code, Codex CLI, or Cursor CLI.
 
 ## Inputs
 

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -14,7 +14,7 @@ Stage and commit current changes with a concise, well-formed commit message base
 
 ## Agent Compatibility
 
-This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, or Cursor CLI.
+This skill is tool-agnostic and can be executed by Claude Code, Codex CLI, or Cursor CLI.
 
 ## Inputs
 

--- a/skills/commit/SKILL.md
+++ b/skills/commit/SKILL.md
@@ -14,7 +14,7 @@ Stage and commit current changes with a concise, well-formed commit message base
 
 ## Agent Compatibility
 
-This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, GitHub Copilot CLI, or Gemini CLI.
+This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, or Cursor CLI.
 
 ## Inputs
 

--- a/skills/pr-feedback-triage/SKILL.md
+++ b/skills/pr-feedback-triage/SKILL.md
@@ -1,9 +1,9 @@
 ---
-name: pr-review-comment-triage
+name: pr-feedback-triage
 description: Triage pull request review comments into fixes, replies, clarification requests, or open follow-ups while respecting safe execution modes.
 ---
 
-# PR Review Comment Triage
+# PR Feedback Triage
 
 Triage pull request review feedback, decide what action each thread needs, make focused fixes when allowed, and report or resolve only what is actually handled.
 

--- a/skills/pr-review-comment-triage/SKILL.md
+++ b/skills/pr-review-comment-triage/SKILL.md
@@ -17,7 +17,7 @@ Do not use this skill for a first-pass code review with no existing feedback; us
 
 ## Agent Compatibility
 
-This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, GitHub Copilot CLI, Gemini CLI, or any agent with repository and pull request access.
+This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, Cursor CLI, or any agent with repository and pull request access.
 
 Use the active platform tooling for pull request operations. For GitHub, prefer `gh pr view`, `gh pr checkout`, `gh pr diff`, and `gh api graphql` when available. If the current environment has read-only platform credentials, perform the code changes and provide the exact replies or resolution actions for a maintainer to apply manually.
 

--- a/skills/pr-review-comment-triage/SKILL.md
+++ b/skills/pr-review-comment-triage/SKILL.md
@@ -17,7 +17,7 @@ Do not use this skill for a first-pass code review with no existing feedback; us
 
 ## Agent Compatibility
 
-This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, Cursor CLI, or any agent with repository and pull request access.
+This skill is tool-agnostic and can be executed by Claude Code, Codex CLI, Cursor CLI, or any agent with repository and pull request access.
 
 Use the active platform tooling for pull request operations. For GitHub, prefer `gh pr view`, `gh pr checkout`, `gh pr diff`, and `gh api graphql` when available. If the current environment has read-only platform credentials, perform the code changes and provide the exact replies or resolution actions for a maintainer to apply manually.
 

--- a/skills/pr-review-comment-triage/SKILL.md
+++ b/skills/pr-review-comment-triage/SKILL.md
@@ -1,268 +1,98 @@
 ---
 name: pr-review-comment-triage
-description: Triage and resolve review comments on a pull request. Use when the user asks to address PR feedback, review comments, requested changes, or unresolved review threads.
+description: Triage pull request review comments into fixes, replies, clarification requests, or open follow-ups while respecting safe execution modes.
 ---
 
 # PR Review Comment Triage
 
-Triage pull request review comments, implement the accepted fixes when allowed, and reply to or resolve review threads when appropriate and allowed.
+Triage pull request review feedback, decide what action each thread needs, make focused fixes when allowed, and report or resolve only what is actually handled.
 
 ## When to Use
 
-- A pull request has review comments, requested changes, or unresolved review threads.
-- The user asks to address, fix, respond to, or resolve PR feedback.
-- The user provides a PR URL, PR number, current branch with an associated PR, or copied review comments.
+- A PR has review comments, requested changes, or unresolved review threads.
+- The user asks to address, respond to, or resolve PR feedback.
+- The user provides a PR URL/number, a branch with an associated PR, or copied comments.
 
 Do not use this skill for a first-pass code review with no existing feedback; use a code review skill instead.
-
-## Agent Compatibility
-
-This skill is tool-agnostic and can be executed by Claude Code, Codex CLI, Cursor CLI, or any agent with repository and pull request access.
-
-Use the active platform tooling for pull request operations. For GitHub, prefer `gh pr view`, `gh pr checkout`, `gh pr diff`, and `gh api graphql` when available. If the current environment has read-only platform credentials, perform the code changes and provide the exact replies or resolution actions for a maintainer to apply manually.
 
 ## Inputs
 
 - Pull request URL or number, or a current branch that has an associated pull request.
-- Repository checkout or platform API access with permission to inspect the PR diff, plus branch edit access when fixes are allowed.
-- Optional reviewer priorities from the user, such as "only address blocking comments" or "do not reply on GitHub".
+- Repository checkout or platform access sufficient to inspect the PR diff and review feedback.
+- Optional reviewer priorities from the user, such as "only address blocking comments" or "do not reply on the PR platform".
 - Optional operating mode flags: `dry_run`, `no_push`, and `no_reply`.
 
 If no PR or review comments are identifiable, ask for the target PR or the copied comments before proceeding.
 
-## Operating Modes
+## Modes
 
-Use normal mode unless the user or environment specifies one of these flags:
-
-- `dry_run`: inspect review feedback and report the triage only. Do not edit files, run write-mode formatters, commit, push, post GitHub replies, or resolve review threads.
+- `dry_run`: inspect review feedback and report the triage only. Do not edit files, run write-mode formatters, commit, push, post replies, or resolve review threads.
 - `no_push`: local edits and verification are allowed, but do not push commits or otherwise update the remote branch. Report the local diff or local commits that still need to be pushed.
-- `no_reply`: do not post GitHub replies, submit reviews, or resolve review threads. Provide suggested replies and resolution actions in the final report instead.
+- `no_reply`: do not post replies, submit reviews, or resolve review threads. Provide suggested replies and resolution actions in the final report instead.
 
-When a mode disables an action, skip that destructive or externally visible action even if it appears later in the normal workflow.
+When a mode disables an action, skip that destructive or externally visible action even if normal workflow text would otherwise allow it.
 
-## Workflow
+## Flow
 
-1. **Establish the PR target**
-   - Determine the PR number, URL, base branch, head branch, repository owner/name, and current local branch.
-   - If the local branch is not the PR head branch, check out or fetch the PR head branch before editing unless `dry_run` only needs remote inspection.
-   - Inspect repository instructions such as `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, and nearby package guidance relevant to changed files.
-   - Capture the current working tree state and do not overwrite unrelated user changes.
-
-2. **Collect review feedback**
-   - Gather unresolved review threads, requested-change reviews, top-level PR comments, and relevant CI annotations if the user included them in the requested feedback.
-   - For GitHub review threads, collect at least:
-     - Thread ID and URL
-     - Resolution state and outdated state
-     - File path, line or original line, and diff hunk
-     - All comments in the thread with author, timestamp, and body
-   - Also inspect the PR diff and the current file contents around each commented line, since comment line numbers can drift after new commits.
-
-   Example GitHub GraphQL query shape for paginating review threads:
-
-   ```bash
-   THREAD_CURSOR=null
-   gh api graphql \
-     -f owner='<owner>' \
-     -f repo='<repo>' \
-     -F number='<pr-number>' \
-     -F threadCursor="$THREAD_CURSOR" \
-     -f query='
-   query($owner: String!, $repo: String!, $number: Int!, $threadCursor: String) {
-     repository(owner: $owner, name: $repo) {
-       pullRequest(number: $number) {
-         reviewThreads(first: 100, after: $threadCursor) {
-           pageInfo {
-             hasNextPage
-             endCursor
-           }
-           nodes {
-             id
-             isResolved
-             isOutdated
-             path
-             line
-             originalLine
-             comments(first: 20) {
-               pageInfo {
-                 hasNextPage
-                 endCursor
-               }
-               nodes {
-                 author { login }
-                 body
-                 createdAt
-                 url
-               }
-             }
-           }
-         }
-       }
-     }
-   }'
-   ```
-
-   Repeat the query with `THREAD_CURSOR` set to `reviewThreads.pageInfo.endCursor` while `reviewThreads.pageInfo.hasNextPage` is true. For any thread whose `comments.pageInfo.hasNextPage` is true, paginate that thread's comments separately:
-
-   ```bash
-   COMMENT_CURSOR=null
-   gh api graphql \
-     -f threadId='<thread-id>' \
-     -F commentCursor="$COMMENT_CURSOR" \
-     -f query='
-   query($threadId: ID!, $commentCursor: String) {
-     node(id: $threadId) {
-       ... on PullRequestReviewThread {
-         comments(first: 100, after: $commentCursor) {
-           pageInfo {
-             hasNextPage
-             endCursor
-           }
-           nodes {
-             author { login }
-             body
-             createdAt
-             url
-           }
-         }
-       }
-     }
-   }'
-   ```
-
-   Repeat the comment query with `COMMENT_CURSOR` set to `comments.pageInfo.endCursor` until every thread's comments are collected. Do not silently inspect only the first page of review threads or comments.
-
-3. **Classify every comment**
-   - Create a tracking list with one item per thread or standalone comment.
-   - Classify each item as one of:
-     - **Fix**: Valid requested change that should be implemented.
-     - **Answer**: Needs an explanation or confirmation, but no code change.
-     - **Clarify**: Ambiguous, conflicting, or missing enough context to act safely.
-     - **Already addressed**: Current code already satisfies the comment.
-     - **Outdated**: The commented code no longer exists or the issue was removed by later commits.
-     - **Won't fix**: Valid concern that should not be changed, with a clear reason.
-   - Prefer fixing concrete correctness, security, test, compatibility, and maintainability issues over stylistic churn.
-   - Do not dismiss an outdated thread until current code proves the concern is gone.
-
-4. **Plan the changes**
-   - Group related fixes by subsystem to minimize churn.
-   - Identify tests, linters, formatters, snapshots, generated files, and documentation that should change with the fixes.
-   - If comments conflict, follow repository policy first, then maintainer comments, then reviewer suggestions. Explain the conflict in the thread or final summary.
-   - If a comment is ambiguous but a small safe fix clearly satisfies it, implement the fix. Otherwise ask for clarification instead of guessing.
-   - If `dry_run` is enabled, stop after producing the triage, proposed fixes, verification plan, and suggested replies. Do not edit files.
-
-5. **Implement accepted fixes when allowed**
-   - Make the smallest coherent code changes needed to resolve the accepted comments.
-   - Preserve unrelated user changes and avoid broad refactors.
-   - Update or add tests for behavioral changes and reviewer-requested coverage.
-   - Keep a mapping from each changed file or commit back to the comments it resolves.
-   - Skip this step in `dry_run`.
-
-6. **Verify**
-   - Run targeted tests for changed behavior.
-   - Run repository-required formatting, linting, typechecking, or local QA commands when practical.
-   - If a check cannot run, record the command attempted, the failure, and the residual risk.
-   - Re-read the updated diff and each addressed comment to confirm the fix actually resolves the concern.
-   - In `dry_run`, verify by inspecting the current code and report the commands that should be run if fixes are later implemented.
-
-7. **Commit and push when allowed**
-   - In normal mode, commit the changes with a message that summarizes the review feedback addressed, then push the PR head branch.
-   - In `dry_run`, do not commit or push.
-   - In `no_push`, do not push. Leave changes uncommitted or committed locally according to the user's request and report the exact local state.
-   - If multiple independent fixes are large enough to warrant separate commits, keep each commit focused and explain the grouping.
-
-8. **Reply and resolve threads when allowed**
-   - For each thread, leave a concise reply before resolving when:
-     - A code change was made.
-     - No code change was made but an explanation is needed.
-     - The thread is outdated, duplicate, or intentionally not fixed.
-   - Include what changed and, when useful, the commit SHA or verification command.
-   - Resolve a review thread only after the fix is pushed or the answer clearly closes the discussion.
-   - Do not resolve threads that need reviewer clarification or product decisions.
-   - In `dry_run` or `no_reply`, do not post replies or resolve threads; provide suggested replies and resolution actions in the final report.
-   - In `no_push`, do not resolve threads for code changes that are only local. Provide suggested replies until the fixes are pushed.
-
-   Example GitHub GraphQL mutations:
-
-   ```bash
-   gh api graphql -f thread_id='<thread-id>' -f body='Fixed in <commit-sha>; verified with <command>.' -f query='
-   mutation($thread_id: ID!, $body: String!) {
-     addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $thread_id, body: $body}) {
-       comment { url }
-     }
-   }'
-
-   gh api graphql -f thread_id='<thread-id>' -f query='
-   mutation($thread_id: ID!) {
-     resolveReviewThread(input: {threadId: $thread_id}) {
-       thread { isResolved }
-     }
-   }'
-   ```
-
-9. **Report results**
-   - Summarize each comment disposition: fixed, answered, resolved as outdated, left open, or not fixed.
-   - List commits pushed, local commits, or local diffs according to the active mode.
-   - List verification commands run, or the verification plan for `dry_run`.
-   - Call out unresolved threads, requested clarification, skipped checks, and any follow-up needed from reviewers.
-
-## Reply Guidelines
-
-- Be concise, factual, and appreciative without adding filler.
-- Reference the specific fix instead of saying only "done".
-- Avoid arguing with reviewers. When declining a suggestion, explain the tradeoff and offer an alternative if one exists.
-- Do not reveal secrets or paste sensitive data from diffs, logs, or comments.
-- Do not mark a comment resolved merely because it is inconvenient or because CI passed.
-
-## Output Format
-
-### Final Response
-
-```markdown
-Addressed PR review feedback.
-
-- Mode: <normal / dry_run / no_push / no_reply>
-- Fixed: <N> thread(s)
-- Answered without code change: <N> thread(s)
-- Resolved as outdated/already addressed: <N> thread(s)
-- Left open: <N> thread(s), because <reason>
-
-Commits:
-
-- <sha> <subject>
-- <none; dry_run/no_push/no local commit>
-
-Verification:
-
-- `<command>` - passed
-- `<command>` - failed/skipped: <reason>
-- Planned only: `<command>` - <dry_run reason>
-
-Follow-up:
-
-- <none or remaining reviewer/product questions>
+```mermaid
+flowchart TD
+  A[Identify PR and review feedback] --> B[Inspect current diff and code]
+  B --> C{Classify each thread}
+  C -->|Fix| D[Implement minimal change]
+  C -->|Answer| E[Prepare concise reply]
+  C -->|Clarify| F[Leave open with question]
+  C -->|Already addressed or Outdated| G[Prepare explanation]
+  C -->|Won't fix| H[Document reason]
+  D --> I[Verify]
+  I --> J{Mode}
+  E --> J
+  F --> J
+  G --> J
+  H --> J
+  J -->|dry_run| K[Report only]
+  J -->|no_push| L[Report local diff or commits]
+  J -->|no_reply| M[Report suggested replies/actions]
+  J -->|normal| N[Commit/push if changed, reply/resolve if appropriate]
+  K --> O[Final summary]
+  L --> O
+  M --> O
+  N --> O
 ```
 
-### Manual Resolution Needed
+## Compact Workflow
 
-Use this when the environment cannot post replies or resolve threads:
+1. **Collect all relevant feedback**
+   - Identify the PR and gather unresolved review threads, requested-change reviews, and copied comments.
+   - Use platform-native APIs/CLI when available. Paginate results; do not inspect only the first page of threads or comments.
+   - Compare each comment with the current diff and file contents because review lines can become outdated.
 
-```markdown
-Implemented the fixes, but could not update PR threads from this environment.
+2. **Classify each thread/comment**
+   - **Fix**: Valid requested change; make the smallest focused edit when not in `dry_run`.
+   - **Answer**: No code change needed; prepare a concise explanation.
+   - **Clarify**: Ambiguous, conflicting, or missing context; leave open with a question.
+   - **Already addressed**: Current code already satisfies it; prepare evidence.
+   - **Outdated**: Commented code or issue no longer exists; prepare evidence.
+   - **Won't fix**: Valid concern intentionally not changed; document the reason.
 
-Suggested replies:
+3. **Act according to the classification and mode**
+   - Keep edits scoped to the review feedback.
+   - In `dry_run`, stop at triage, proposed fixes, suggested replies, and verification plan.
+   - In `no_push`, local edits are allowed, but do not push or resolve threads for local-only fixes.
+   - In `no_reply`, do not post replies or resolve threads; report suggested replies/actions instead.
 
-1. <thread URL or ID>
-   Reply: <message>
-   Action: resolve / leave open
+4. **Verify before claiming completion**
+   - For fixes, run appropriate checks or explain why they could not run.
+   - Re-inspect the updated diff and comment context to confirm the concern is resolved.
+   - Do not mark a thread resolved if it still needs reviewer, maintainer, or product input.
 
-Verification:
+5. **Finish**
+   - Normal mode: commit/push changes when appropriate, then reply and resolve only threads that are actually handled.
+   - Safe modes: report the local state and the exact replies/resolution actions a human could take.
 
-- `<command>` - <result>
-```
+## Final Summary Checklist
 
-## Constraints
-
-- Keep the work scoped to the PR feedback unless the user asks for broader changes.
-- Do not resolve threads that still need human input.
-- Do not include unrelated changes in commits.
-- Prefer platform-native review thread APIs over ad hoc scraping.
+- Mode used: `normal`, `dry_run`, `no_push`, or `no_reply`
+- Counts by disposition: fixed, answered, clarified/left open, already addressed, outdated, won't fix
+- Verification run or planned
+- Commits pushed, local diff/commits, or "none"
+- Remaining open items and who needs to respond

--- a/skills/pr-review-comment-triage/SKILL.md
+++ b/skills/pr-review-comment-triage/SKILL.md
@@ -5,7 +5,7 @@ description: Triage and resolve review comments on a pull request. Use when the 
 
 # PR Review Comment Triage
 
-Triage pull request review comments, implement the accepted fixes, reply to reviewers when appropriate, and resolve review threads once the underlying concern is handled.
+Triage pull request review comments, implement the accepted fixes when allowed, and reply to or resolve review threads when appropriate and allowed.
 
 ## When to Use
 
@@ -24,16 +24,27 @@ Use the active platform tooling for pull request operations. For GitHub, prefer 
 ## Inputs
 
 - Pull request URL or number, or a current branch that has an associated pull request.
-- Repository checkout with permission to inspect the PR diff and edit the branch.
+- Repository checkout or platform API access with permission to inspect the PR diff, plus branch edit access when fixes are allowed.
 - Optional reviewer priorities from the user, such as "only address blocking comments" or "do not reply on GitHub".
+- Optional operating mode flags: `dry_run`, `no_push`, and `no_reply`.
 
 If no PR or review comments are identifiable, ask for the target PR or the copied comments before proceeding.
+
+## Operating Modes
+
+Use normal mode unless the user or environment specifies one of these flags:
+
+- `dry_run`: inspect review feedback and report the triage only. Do not edit files, run write-mode formatters, commit, push, post GitHub replies, or resolve review threads.
+- `no_push`: local edits and verification are allowed, but do not push commits or otherwise update the remote branch. Report the local diff or local commits that still need to be pushed.
+- `no_reply`: do not post GitHub replies, submit reviews, or resolve review threads. Provide suggested replies and resolution actions in the final report instead.
+
+When a mode disables an action, skip that destructive or externally visible action even if it appears later in the normal workflow.
 
 ## Workflow
 
 1. **Establish the PR target**
    - Determine the PR number, URL, base branch, head branch, repository owner/name, and current local branch.
-   - If the local branch is not the PR head branch, check out or fetch the PR head branch before editing.
+   - If the local branch is not the PR head branch, check out or fetch the PR head branch before editing unless `dry_run` only needs remote inspection.
    - Inspect repository instructions such as `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, and nearby package guidance relevant to changed files.
    - Capture the current working tree state and do not overwrite unrelated user changes.
 
@@ -46,14 +57,24 @@ If no PR or review comments are identifiable, ask for the target PR or the copie
      - All comments in the thread with author, timestamp, and body
    - Also inspect the PR diff and the current file contents around each commented line, since comment line numbers can drift after new commits.
 
-   Example GitHub GraphQL query shape:
+   Example GitHub GraphQL query shape for paginating review threads:
 
    ```bash
-   gh api graphql -f owner='<owner>' -f repo='<repo>' -F number='<pr-number>' -f query='
-   query($owner: String!, $repo: String!, $number: Int!) {
+   THREAD_CURSOR=null
+   gh api graphql \
+     -f owner='<owner>' \
+     -f repo='<repo>' \
+     -F number='<pr-number>' \
+     -F threadCursor="$THREAD_CURSOR" \
+     -f query='
+   query($owner: String!, $repo: String!, $number: Int!, $threadCursor: String) {
      repository(owner: $owner, name: $repo) {
        pullRequest(number: $number) {
-         reviewThreads(first: 100) {
+         reviewThreads(first: 100, after: $threadCursor) {
+           pageInfo {
+             hasNextPage
+             endCursor
+           }
            nodes {
              id
              isResolved
@@ -62,6 +83,10 @@ If no PR or review comments are identifiable, ask for the target PR or the copie
              line
              originalLine
              comments(first: 20) {
+               pageInfo {
+                 hasNextPage
+                 endCursor
+               }
                nodes {
                  author { login }
                  body
@@ -76,7 +101,35 @@ If no PR or review comments are identifiable, ask for the target PR or the copie
    }'
    ```
 
-   If more than 100 threads or 20 comments per thread exist, paginate until all relevant unresolved feedback has been collected.
+   Repeat the query with `THREAD_CURSOR` set to `reviewThreads.pageInfo.endCursor` while `reviewThreads.pageInfo.hasNextPage` is true. For any thread whose `comments.pageInfo.hasNextPage` is true, paginate that thread's comments separately:
+
+   ```bash
+   COMMENT_CURSOR=null
+   gh api graphql \
+     -f threadId='<thread-id>' \
+     -F commentCursor="$COMMENT_CURSOR" \
+     -f query='
+   query($threadId: ID!, $commentCursor: String) {
+     node(id: $threadId) {
+       ... on PullRequestReviewThread {
+         comments(first: 100, after: $commentCursor) {
+           pageInfo {
+             hasNextPage
+             endCursor
+           }
+           nodes {
+             author { login }
+             body
+             createdAt
+             url
+           }
+         }
+       }
+     }
+   }'
+   ```
+
+   Repeat the comment query with `COMMENT_CURSOR` set to `comments.pageInfo.endCursor` until every thread's comments are collected. Do not silently inspect only the first page of review threads or comments.
 
 3. **Classify every comment**
    - Create a tracking list with one item per thread or standalone comment.
@@ -95,25 +148,29 @@ If no PR or review comments are identifiable, ask for the target PR or the copie
    - Identify tests, linters, formatters, snapshots, generated files, and documentation that should change with the fixes.
    - If comments conflict, follow repository policy first, then maintainer comments, then reviewer suggestions. Explain the conflict in the thread or final summary.
    - If a comment is ambiguous but a small safe fix clearly satisfies it, implement the fix. Otherwise ask for clarification instead of guessing.
+   - If `dry_run` is enabled, stop after producing the triage, proposed fixes, verification plan, and suggested replies. Do not edit files.
 
-5. **Implement accepted fixes**
+5. **Implement accepted fixes when allowed**
    - Make the smallest coherent code changes needed to resolve the accepted comments.
    - Preserve unrelated user changes and avoid broad refactors.
    - Update or add tests for behavioral changes and reviewer-requested coverage.
    - Keep a mapping from each changed file or commit back to the comments it resolves.
+   - Skip this step in `dry_run`.
 
 6. **Verify**
    - Run targeted tests for changed behavior.
    - Run repository-required formatting, linting, typechecking, or local QA commands when practical.
    - If a check cannot run, record the command attempted, the failure, and the residual risk.
    - Re-read the updated diff and each addressed comment to confirm the fix actually resolves the concern.
+   - In `dry_run`, verify by inspecting the current code and report the commands that should be run if fixes are later implemented.
 
-7. **Commit and push**
-   - Commit the changes with a message that summarizes the review feedback addressed.
-   - Push the PR head branch.
+7. **Commit and push when allowed**
+   - In normal mode, commit the changes with a message that summarizes the review feedback addressed, then push the PR head branch.
+   - In `dry_run`, do not commit or push.
+   - In `no_push`, do not push. Leave changes uncommitted or committed locally according to the user's request and report the exact local state.
    - If multiple independent fixes are large enough to warrant separate commits, keep each commit focused and explain the grouping.
 
-8. **Reply and resolve threads**
+8. **Reply and resolve threads when allowed**
    - For each thread, leave a concise reply before resolving when:
      - A code change was made.
      - No code change was made but an explanation is needed.
@@ -121,6 +178,8 @@ If no PR or review comments are identifiable, ask for the target PR or the copie
    - Include what changed and, when useful, the commit SHA or verification command.
    - Resolve a review thread only after the fix is pushed or the answer clearly closes the discussion.
    - Do not resolve threads that need reviewer clarification or product decisions.
+   - In `dry_run` or `no_reply`, do not post replies or resolve threads; provide suggested replies and resolution actions in the final report.
+   - In `no_push`, do not resolve threads for code changes that are only local. Provide suggested replies until the fixes are pushed.
 
    Example GitHub GraphQL mutations:
 
@@ -142,7 +201,8 @@ If no PR or review comments are identifiable, ask for the target PR or the copie
 
 9. **Report results**
    - Summarize each comment disposition: fixed, answered, resolved as outdated, left open, or not fixed.
-   - List commits pushed and verification commands run.
+   - List commits pushed, local commits, or local diffs according to the active mode.
+   - List verification commands run, or the verification plan for `dry_run`.
    - Call out unresolved threads, requested clarification, skipped checks, and any follow-up needed from reviewers.
 
 ## Reply Guidelines
@@ -160,6 +220,7 @@ If no PR or review comments are identifiable, ask for the target PR or the copie
 ```markdown
 Addressed PR review feedback.
 
+- Mode: <normal / dry_run / no_push / no_reply>
 - Fixed: <N> thread(s)
 - Answered without code change: <N> thread(s)
 - Resolved as outdated/already addressed: <N> thread(s)
@@ -168,11 +229,13 @@ Addressed PR review feedback.
 Commits:
 
 - <sha> <subject>
+- <none; dry_run/no_push/no local commit>
 
 Verification:
 
 - `<command>` - passed
 - `<command>` - failed/skipped: <reason>
+- Planned only: `<command>` - <dry_run reason>
 
 Follow-up:
 

--- a/skills/pr-review-comment-triage/SKILL.md
+++ b/skills/pr-review-comment-triage/SKILL.md
@@ -1,0 +1,205 @@
+---
+name: pr-review-comment-triage
+description: Triage and resolve review comments on a pull request. Use when the user asks to address PR feedback, review comments, requested changes, or unresolved review threads.
+---
+
+# PR Review Comment Triage
+
+Triage pull request review comments, implement the accepted fixes, reply to reviewers when appropriate, and resolve review threads once the underlying concern is handled.
+
+## When to Use
+
+- A pull request has review comments, requested changes, or unresolved review threads.
+- The user asks to address, fix, respond to, or resolve PR feedback.
+- The user provides a PR URL, PR number, current branch with an associated PR, or copied review comments.
+
+Do not use this skill for a first-pass code review with no existing feedback; use a code review skill instead.
+
+## Agent Compatibility
+
+This skill is tool-agnostic and can be executed by Claude Code, OpenAI Codex CLI, GitHub Copilot CLI, Gemini CLI, or any agent with repository and pull request access.
+
+Use the active platform tooling for pull request operations. For GitHub, prefer `gh pr view`, `gh pr checkout`, `gh pr diff`, and `gh api graphql` when available. If the current environment has read-only platform credentials, perform the code changes and provide the exact replies or resolution actions for a maintainer to apply manually.
+
+## Inputs
+
+- Pull request URL or number, or a current branch that has an associated pull request.
+- Repository checkout with permission to inspect the PR diff and edit the branch.
+- Optional reviewer priorities from the user, such as "only address blocking comments" or "do not reply on GitHub".
+
+If no PR or review comments are identifiable, ask for the target PR or the copied comments before proceeding.
+
+## Workflow
+
+1. **Establish the PR target**
+   - Determine the PR number, URL, base branch, head branch, repository owner/name, and current local branch.
+   - If the local branch is not the PR head branch, check out or fetch the PR head branch before editing.
+   - Inspect repository instructions such as `AGENTS.md`, `CLAUDE.md`, `CONTRIBUTING.md`, and nearby package guidance relevant to changed files.
+   - Capture the current working tree state and do not overwrite unrelated user changes.
+
+2. **Collect review feedback**
+   - Gather unresolved review threads, requested-change reviews, top-level PR comments, and relevant CI annotations if the user included them in the requested feedback.
+   - For GitHub review threads, collect at least:
+     - Thread ID and URL
+     - Resolution state and outdated state
+     - File path, line or original line, and diff hunk
+     - All comments in the thread with author, timestamp, and body
+   - Also inspect the PR diff and the current file contents around each commented line, since comment line numbers can drift after new commits.
+
+   Example GitHub GraphQL query shape:
+
+   ```bash
+   gh api graphql -f owner='<owner>' -f repo='<repo>' -F number='<pr-number>' -f query='
+   query($owner: String!, $repo: String!, $number: Int!) {
+     repository(owner: $owner, name: $repo) {
+       pullRequest(number: $number) {
+         reviewThreads(first: 100) {
+           nodes {
+             id
+             isResolved
+             isOutdated
+             path
+             line
+             originalLine
+             comments(first: 20) {
+               nodes {
+                 author { login }
+                 body
+                 createdAt
+                 url
+               }
+             }
+           }
+         }
+       }
+     }
+   }'
+   ```
+
+   If more than 100 threads or 20 comments per thread exist, paginate until all relevant unresolved feedback has been collected.
+
+3. **Classify every comment**
+   - Create a tracking list with one item per thread or standalone comment.
+   - Classify each item as one of:
+     - **Fix**: Valid requested change that should be implemented.
+     - **Answer**: Needs an explanation or confirmation, but no code change.
+     - **Clarify**: Ambiguous, conflicting, or missing enough context to act safely.
+     - **Already addressed**: Current code already satisfies the comment.
+     - **Outdated**: The commented code no longer exists or the issue was removed by later commits.
+     - **Won't fix**: Valid concern that should not be changed, with a clear reason.
+   - Prefer fixing concrete correctness, security, test, compatibility, and maintainability issues over stylistic churn.
+   - Do not dismiss an outdated thread until current code proves the concern is gone.
+
+4. **Plan the changes**
+   - Group related fixes by subsystem to minimize churn.
+   - Identify tests, linters, formatters, snapshots, generated files, and documentation that should change with the fixes.
+   - If comments conflict, follow repository policy first, then maintainer comments, then reviewer suggestions. Explain the conflict in the thread or final summary.
+   - If a comment is ambiguous but a small safe fix clearly satisfies it, implement the fix. Otherwise ask for clarification instead of guessing.
+
+5. **Implement accepted fixes**
+   - Make the smallest coherent code changes needed to resolve the accepted comments.
+   - Preserve unrelated user changes and avoid broad refactors.
+   - Update or add tests for behavioral changes and reviewer-requested coverage.
+   - Keep a mapping from each changed file or commit back to the comments it resolves.
+
+6. **Verify**
+   - Run targeted tests for changed behavior.
+   - Run repository-required formatting, linting, typechecking, or local QA commands when practical.
+   - If a check cannot run, record the command attempted, the failure, and the residual risk.
+   - Re-read the updated diff and each addressed comment to confirm the fix actually resolves the concern.
+
+7. **Commit and push**
+   - Commit the changes with a message that summarizes the review feedback addressed.
+   - Push the PR head branch.
+   - If multiple independent fixes are large enough to warrant separate commits, keep each commit focused and explain the grouping.
+
+8. **Reply and resolve threads**
+   - For each thread, leave a concise reply before resolving when:
+     - A code change was made.
+     - No code change was made but an explanation is needed.
+     - The thread is outdated, duplicate, or intentionally not fixed.
+   - Include what changed and, when useful, the commit SHA or verification command.
+   - Resolve a review thread only after the fix is pushed or the answer clearly closes the discussion.
+   - Do not resolve threads that need reviewer clarification or product decisions.
+
+   Example GitHub GraphQL mutations:
+
+   ```bash
+   gh api graphql -f thread_id='<thread-id>' -f body='Fixed in <commit-sha>; verified with <command>.' -f query='
+   mutation($thread_id: ID!, $body: String!) {
+     addPullRequestReviewThreadReply(input: {pullRequestReviewThreadId: $thread_id, body: $body}) {
+       comment { url }
+     }
+   }'
+
+   gh api graphql -f thread_id='<thread-id>' -f query='
+   mutation($thread_id: ID!) {
+     resolveReviewThread(input: {threadId: $thread_id}) {
+       thread { isResolved }
+     }
+   }'
+   ```
+
+9. **Report results**
+   - Summarize each comment disposition: fixed, answered, resolved as outdated, left open, or not fixed.
+   - List commits pushed and verification commands run.
+   - Call out unresolved threads, requested clarification, skipped checks, and any follow-up needed from reviewers.
+
+## Reply Guidelines
+
+- Be concise, factual, and appreciative without adding filler.
+- Reference the specific fix instead of saying only "done".
+- Avoid arguing with reviewers. When declining a suggestion, explain the tradeoff and offer an alternative if one exists.
+- Do not reveal secrets or paste sensitive data from diffs, logs, or comments.
+- Do not mark a comment resolved merely because it is inconvenient or because CI passed.
+
+## Output Format
+
+### Final Response
+
+```markdown
+Addressed PR review feedback.
+
+- Fixed: <N> thread(s)
+- Answered without code change: <N> thread(s)
+- Resolved as outdated/already addressed: <N> thread(s)
+- Left open: <N> thread(s), because <reason>
+
+Commits:
+
+- <sha> <subject>
+
+Verification:
+
+- `<command>` - passed
+- `<command>` - failed/skipped: <reason>
+
+Follow-up:
+
+- <none or remaining reviewer/product questions>
+```
+
+### Manual Resolution Needed
+
+Use this when the environment cannot post replies or resolve threads:
+
+```markdown
+Implemented the fixes, but could not update PR threads from this environment.
+
+Suggested replies:
+
+1. <thread URL or ID>
+   Reply: <message>
+   Action: resolve / leave open
+
+Verification:
+
+- `<command>` - <result>
+```
+
+## Constraints
+
+- Keep the work scoped to the PR feedback unless the user asks for broader changes.
+- Do not resolve threads that still need human input.
+- Do not include unrelated changes in commits.
+- Prefer platform-native review thread APIs over ad hoc scraping.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Add a portable `pr-feedback-triage` skill for collecting, classifying, fixing, replying to, and resolving PR review feedback.
- Refactor the skill into a compact mode-aware workflow with a Mermaid decision flowchart.
- Preserve explicit `dry_run`, `no_push`, and `no_reply` modes while removing verbose procedural/API examples.
- Update skill docs to replace GitHub Copilot/Gemini CLI compatibility references with Cursor CLI.
- Standardize documentation wording from `OpenAI Codex CLI` to `Codex CLI`.
- Update the README skill inventory with the new workflow.
- Add restrictive top-level CI workflow permissions so repository QA passes while keeping the Dependabot auto-merge job-specific write scopes.

## Verification
- `npx -y prettier -w './**/*.md'`
- `.agents/skills/local-qa/scripts/qa.sh`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-68dfbf29-8b05-4d82-8bc0-af8bc601c9f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-68dfbf29-8b05-4d82-8bc0-af8bc601c9f6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

