### PR TITLE
Allow gh and GitHub MCP for PR skills

### DIFF
--- a/skills/pr-feedback-triage/SKILL.md
+++ b/skills/pr-feedback-triage/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: pr-feedback-triage
 description: Triage pull request review comments into fixes, replies, clarification requests, or open follow-ups while respecting safe execution modes.
+allowed-tools: Bash(git:*), Bash(gh:*), mcp__github__*, Read, Grep, Glob, Edit, MultiEdit, Write
 ---
 
 # PR Feedback Triage
@@ -44,7 +45,7 @@ When a mode disables an action, skip that destructive or externally visible acti
 Gather the complete feedback set before editing:
 
 - Fetch unresolved review threads, requested-change reviews, inline comments, copied comments, and PR-level summary comments.
-- Use platform-native APIs/CLI when available. Paginate results; do not inspect only the first page of threads or comments.
+- Use whichever authenticated GitHub-capable interface is available and reliable. This skill explicitly permits both `gh` and GitHub MCP tools; paginate results and do not inspect only the first page of threads or comments.
 - For bot reviewers that post both summary comments and inline comments, prefer inline comments for actionable triage. Incorporate summary findings only when they contain distinct severity, rationale, or fix instructions not already captured from inline comments.
 - Summary comments may be excluded from triage when they do not add distinct actionable context.
 - Preserve every thread/comment identifier needed to reply or resolve later.
@@ -99,7 +100,7 @@ For duplicate findings, execute the terminal action for every source thread ID, 
 
 ## GitHub Action Guidance
 
-Prefer platform-native APIs or `gh` commands that expose review-thread resolution state. For GitHub inline review threads, use the thread node ID and the GraphQL `resolveReviewThread` mutation rather than assuming that a reply resolves the conversation.
+Use whichever authenticated GitHub-capable interface is available and reliable, preferably `gh` or GitHub MCP. Prefer interfaces that expose review-thread resolution state. For GitHub inline review threads, use the thread node ID and the GraphQL `resolveReviewThread` mutation, or an equivalent GitHub MCP resolve-thread tool, rather than assuming that a reply resolves the conversation.
 
 A reliable pattern is:
 

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: pr-review
 description: Run an autonomous CI/GitHub pull request review that inspects PR diffs and posts concise, high-confidence review findings to GitHub by default. Use in CI, GitHub Actions, or other automated PR-review contexts where posting review comments is expected.
-allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git show:*), Bash(git branch:*), Bash(gh auth status:*), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr list:*), Bash(gh pr comment:*), Bash(gh pr review:*), Bash(gh api:*), Read, Grep, Glob
+allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git show:*), Bash(git branch:*), Bash(gh auth status:*), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr list:*), Bash(gh pr comment:*), Bash(gh pr review:*), Bash(gh api:*), mcp__github__*, Read, Grep, Glob
 ---
 
 # PR Review
@@ -39,7 +39,7 @@ Reproduce review methodology and posting policy, not exact Claude runtime behavi
 
 ## Setup and Scope
 
-Use whichever authenticated GitHub-capable interface is available and reliable, such as a platform GitHub tool/MCP, `gh`, or another API client. Keep tool choice internal; satisfy the required capabilities rather than following a fixed command recipe. When using `gh`, verify authentication before review execution with `gh auth status` or an equivalent API check.
+Use whichever authenticated GitHub-capable interface is available and reliable. This skill explicitly permits both `gh` and GitHub MCP tools; select either path based on availability and reliability, and satisfy the required capabilities rather than following a fixed command recipe. When using `gh`, verify authentication before review execution with `gh auth status` or an equivalent API check.
 
 Required capabilities:
 
@@ -57,7 +57,7 @@ In the default mode, the review is not complete until GitHub has accepted a PR c
 
 - Post by default for every successful run, including the clean-result case. Use `dry-run` or `no-post` only when explicitly selected.
 - Include the hidden marker `<!-- pr-review-skill -->` and a current-run marker such as `<!-- pr-review-skill-run: <reviewed-head-sha>-<UTC timestamp or nonce> -->` in the posted body so later runs can identify, update, and verify the skill's own summary without adding visible noise.
-- Prefer one review submission when inline comments are available and safely anchored. Otherwise, post one top-level PR comment. With `gh`, use `gh pr review --comment --body <body>`, `gh pr comment --body <body>`, or an equivalent `gh api` mutation rather than only echoing the body.
+- Prefer one review submission when inline comments are available and safely anchored. Otherwise, post one top-level PR comment. With `gh`, use `gh pr review --comment --body <body>`, `gh pr comment --body <body>`, or an equivalent `gh api` mutation rather than only echoing the body. With GitHub MCP, use equivalent PR review or comment mutation tools rather than only returning the body.
 - If updating an existing summary comment is supported, update only a prior comment containing `<!-- pr-review-skill -->`; otherwise create a new comment/review.
 - After posting, verify the current operation, not any stale marker from an earlier run. Confirm the newly created or updated comment/review ID, an `updated_at` value from the attempted mutation, or the exact expected current body containing both the marker and current-run marker in an issue comment, review body, or inline review comment on the reviewed head SHA.
 - If verification fails, retry once with a top-level PR comment. If that also fails, report posting failure explicitly and exit non-zero in CI/autonomous execution when possible.


### PR DESCRIPTION
## Summary
- permit GitHub MCP tools alongside existing `gh` commands in the `pr-review` skill frontmatter
- add explicit `allowed-tools` for `pr-feedback-triage`, including `gh`, GitHub MCP, git, and editing tools
- clarify that both PR skills may select either `gh` or GitHub MCP based on runtime availability
- mention equivalent GitHub MCP review/comment and review-thread resolution tools in GitHub action guidance

## Testing
- Not run; documentation-only skill update.