### PR TITLE
Update docs for canonical pr-review skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -11,7 +11,6 @@ skills/                        # Source of truth for all skills
 ├── <skill-name>/SKILL.md      # Each skill is a directory with a SKILL.md
 .claude/skills -> ../skills    # Symlink: exposes skills/ to Claude Code runtime
 .agents/skills/                # Per-skill symlinks into skills/ (other runtimes)
-routines/                      # Claude Code Routines (scheduled cloud agents)
 tests/                         # Python tests for QA validation
 pyproject.toml                 # Local QA tooling: ruff, pyright, pytest
 ```
@@ -35,11 +34,11 @@ allowed-tools: Bash, Read, Write, ... # tools the skill may use
    add a per-skill symlink: `ln -s ../../skills/<skill-name> .agents/skills/<skill-name>`.
 3. Keep `description` in the frontmatter precise — it controls when the skill auto-triggers in Claude Code.
 
-## Routines
+## Autonomous and Scheduled Use
 
-The `routines/` directory contains instruction files for [Claude Code Routines](https://code.claude.com/docs/en/routines) — scheduled cloud agents that run autonomously on a cron schedule. Unlike skills (which are invoked interactively), routines run unattended and are self-contained.
+Do not duplicate skill instructions into separate routine files unless a runtime truly requires a self-contained prompt. Prefer invoking the canonical skill under `skills/` and passing schedule, PR, branch, or CI context from the runtime configuration.
 
-Each routine is a plain Markdown file with no frontmatter. The file body is the instruction set the agent executes on each scheduled run.
+For autonomous PR review, `skills/pr-review/SKILL.md` is the source of truth. It defines the GitHub posting contract used by CI, GitHub Actions, Claude Code Routines, and other automated review contexts.
 
 ## Local QA
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ Agent skills for AI coders
 
 ## Overview
 
-Single-source, reusable skills and agent prompts shared across AI coding runtimes. The `skills/` directory is the source of truth and is referenced by runtime-specific integrations via `.claude/skills -> ../skills` and per-skill symlinks under `.agents/skills/` (e.g. `.agents/skills/<skill> -> ../../skills/<skill>`).
+Single-source, reusable skills and agent prompts shared across AI coding runtimes. The `skills/` directory is the source of truth and is referenced by runtime-specific integrations via `.claude/skills -> ../skills` and per-skill symlinks under `.agents/skills/` (e.g. `.agents/skills/<skill> -> ../../skills/<skill>`). Autonomous or scheduled workflows should invoke these canonical skills instead of maintaining duplicate routine prompts.
 
 Each skill directory contains a `SKILL.md` that documents prerequisites and invocation.
 
@@ -17,7 +17,7 @@ Each skill directory contains a `SKILL.md` that documents prerequisites and invo
    ```
 
 2. Pick a runtime and explore the skills in `skills/` and the relevant runtime integration:
-   - **Claude Code:** `.claude/skills -> ../skills` (symlink exposing all skills)
+   - **Claude Code / Claude Code Routines:** `.claude/skills -> ../skills` (symlink exposing all skills)
    - **Codex CLI / other runtimes:** `.agents/skills/` (per-skill symlinks into `skills/`)
 
 3. Open a skill directory and read the `SKILL.md` to learn how to invoke it.
@@ -54,7 +54,6 @@ All skills are located in `skills/` and surfaced through shared discovery or run
 ```
 .
 ├── skills/                  # Shared skill directories (source of truth)
-├── routines/                # Claude Code Routines (scheduled cloud agents)
 ├── .agents/
 │   └── skills/              # Per-skill symlinks into skills/ (other runtimes)
 ├── .claude/
@@ -82,6 +81,8 @@ Install and authenticate the required CLI tools before running skills:
 ## Usage notes
 
 - Skills do not always auto-run; use your agent's skill invocation flow or ask for the skill explicitly.
+- For Claude Code Routines, CI, and other autonomous workflows, invoke the canonical skill under `skills/` and pass runtime-specific context externally.
+- `pr-review` is the source of truth for autonomous PR review behavior, including GitHub posting and verification.
 - If a skill fails, open its `SKILL.md` and verify prerequisites and command syntax.
 
 ## Troubleshooting


### PR DESCRIPTION
## Summary

- Remove stale `routines/` guidance from repository docs after `routines/pr-review.md` was removed.
- Document `skills/` as the canonical path for Claude Code Routines, CI, and other autonomous workflows.
- Clarify that `skills/pr-review/SKILL.md` is the source of truth for autonomous PR review posting and verification behavior.

## Testing

- Not run; documentation-only update.