### PR TITLE
Revert "Rename pr-review and pr-feedback-triage skills to github-prefixed names"

### DIFF
--- a/.agents/skills/github-pr-feedback-triage
+++ b/.agents/skills/github-pr-feedback-triage
@@ -1,1 +1,0 @@
-../../skills/github-pr-feedback-triage

--- a/.agents/skills/github-pr-review
+++ b/.agents/skills/github-pr-review
@@ -1,1 +1,0 @@
-../../skills/github-pr-review

--- a/.agents/skills/pr-feedback-triage
+++ b/.agents/skills/pr-feedback-triage
@@ -1,0 +1,1 @@
+../../skills/pr-feedback-triage

--- a/.agents/skills/pr-review
+++ b/.agents/skills/pr-review
@@ -1,0 +1,1 @@
+../../skills/pr-review

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,7 +38,7 @@ allowed-tools: Bash, Read, Write, ... # tools the skill may use
 
 Do not duplicate skill instructions into separate routine files unless a runtime truly requires a self-contained prompt. Prefer invoking the canonical skill under `skills/` and passing schedule, PR, branch, or CI context from the runtime configuration.
 
-For autonomous PR review, `skills/github-pr-review/SKILL.md` is the source of truth. It defines the GitHub posting contract used by CI, GitHub Actions, Claude Code Routines, and other automated review contexts.
+For autonomous PR review, `skills/pr-review/SKILL.md` is the source of truth. It defines the GitHub posting contract used by CI, GitHub Actions, Claude Code Routines, and other automated review contexts.
 
 ## Local QA
 

--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ All skills are located in `skills/` and surfaced through shared discovery or run
 
 - `code-review` - Comprehensive multi-agent code review for pull requests
 - `code-simplifier` - Simplify and refine code for clarity and maintainability
-- `github-pr-feedback-triage` - Triage and resolve pull request review feedback
-- `github-pr-review` - Autonomous CI/GitHub PR review that posts concise, high-confidence findings by default
+- `pr-feedback-triage` - Triage and resolve pull request review feedback
+- `pr-review` - Autonomous CI/GitHub PR review that posts concise, high-confidence findings by default
 - `security-guidance` - Security-focused review of code changes, diffs, commits, and pull requests
 
 ### AI Tools
@@ -82,7 +82,7 @@ Install and authenticate the required CLI tools before running skills:
 
 - Skills do not always auto-run; use your agent's skill invocation flow or ask for the skill explicitly.
 - For Claude Code Routines, CI, and other autonomous workflows, invoke the canonical skill under `skills/` and pass runtime-specific context externally.
-- `github-pr-review` is the source of truth for autonomous PR review behavior, including GitHub posting and verification.
+- `pr-review` is the source of truth for autonomous PR review behavior, including GitHub posting and verification.
 - If a skill fails, open its `SKILL.md` and verify prerequisites and command syntax.
 
 ## Troubleshooting

--- a/skills/pr-feedback-triage/SKILL.md
+++ b/skills/pr-feedback-triage/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: github-pr-feedback-triage
+name: pr-feedback-triage
 description: Triage pull request review comments into fixes, replies, clarification requests, or open follow-ups while respecting safe execution modes.
 allowed-tools: Bash(git:*), Bash(gh:*), mcp__github__*, Read, Grep, Glob, Edit, MultiEdit, Write
 ---

--- a/skills/pr-review/SKILL.md
+++ b/skills/pr-review/SKILL.md
@@ -1,5 +1,5 @@
 ---
-name: github-pr-review
+name: pr-review
 description: Run an autonomous CI/GitHub pull request review that inspects PR diffs and posts concise, high-confidence review findings to GitHub by default. Use in CI, GitHub Actions, Claude Code Routines, or other automated PR-review contexts where posting review comments is expected.
 allowed-tools: Bash(git status:*), Bash(git diff:*), Bash(git log:*), Bash(git show:*), Bash(git branch:*), Bash(gh auth status:*), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh pr list:*), Bash(gh pr comment:*), Bash(gh pr review:*), Bash(gh api:*), mcp__github__*, Read, Grep, Glob
 ---


### PR DESCRIPTION
Reverts dceoy/ai-coding-agent-skills#33