### PR TITLE
Update reusable workflow references to gha-for-devops

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
   dependabot-auto-merge:
     if: >
       github.event_name == 'pull_request' && github.actor == 'dependabot[bot]'
-    uses: dceoy/gh-actions-for-devops/.github/workflows/dependabot-auto-merge.yml@main  # zizmor: ignore[unpinned-uses]
+    uses: dceoy/gha-for-devops/.github/workflows/dependabot-auto-merge.yml@main  # zizmor: ignore[unpinned-uses]
     permissions:
       contents: write
       pull-requests: write


### PR DESCRIPTION
## Summary
- replace reusable workflow references from `dceoy/gh-actions-for-devops` to `dceoy/gha-for-devops`

## Why
The reusable workflow repository has been renamed to `gha-for-devops`.

## Impact
No workflow behavior is changed; only the repository path used by reusable workflow calls is updated.

## Validation
- confirmed all changed references are under `.github/workflows`
- confirmed the changed files contain no remaining `dceoy/gh-actions-for-devops` reference