### PR TITLE
Add Codex planning and execution subagents

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,5 +1,7 @@
 # Global Codex instructions
 
+This file is the user-wide installation template. Project-local Codex sessions read the same routing policy from the repository-root `AGENTS.md`.
+
 ## Model routing
 
 Use the main agent directly for simple questions and narrow, deterministic edits.

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -1,0 +1,19 @@
+# Global Codex instructions
+
+## Model routing
+
+Use the main agent directly for simple questions and narrow, deterministic edits.
+
+For non-trivial implementation tasks:
+
+1. Spawn `planner_sol` before modifying files.
+2. Wait for the complete plan and preserve its constraints and acceptance checks.
+3. Start exactly one implementation agent:
+   - Use `worker_luna` for localized, low-risk changes with explicit scope and mechanical validation.
+   - Use `worker_terra` for diagnosis, cross-cutting changes, ambiguity, or non-trivial implementation.
+4. If implementation encounters an architectural, security, compatibility, or data-model decision not covered by the plan, return control to `planner_sol` or `advisor_sol`.
+5. Do not run write-capable workers concurrently. A sequential Luna-to-Terra handoff is allowed only after Luna has stopped and reported all partial edits.
+
+For architecture, design evaluation, or technical advice without implementation, spawn `advisor_sol` and keep the work read-only.
+
+Do not spawn a subagent when the main agent can complete the task safely and efficiently without delegation.

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -4,6 +4,8 @@ This file is the user-wide installation template. Project-local Codex sessions r
 
 ## Model routing
 
+This section applies only to the root or main agent that receives the user's task. Named custom agents (`planner_sol`, `advisor_sol`, `worker_terra`, and `worker_luna`) must ignore this section, follow their agent-specific instructions, and must not spawn or delegate to another subagent.
+
 Use the main agent directly for simple questions and narrow, deterministic edits.
 
 For non-trivial implementation tasks:

--- a/.codex/agents/README.md
+++ b/.codex/agents/README.md
@@ -25,26 +25,44 @@ A read-only parent prevents implementation workers from writing. A workspace-wri
 
 ## User-wide installation
 
-The files in this repository are project-scoped by default. To make the agents and routing policy available in every Codex project, copy the agent definitions to `~/.codex/agents/` and the supplied routing instructions to `~/.codex/AGENTS.md`:
+The files in this repository are project-scoped by default. To make the agent definitions available in every Codex project, copy them to `~/.codex/agents/`:
 
 ```bash
 mkdir -p ~/.codex/agents
 cp .codex/agents/*.toml ~/.codex/agents/
-cp .codex/AGENTS.md ~/.codex/AGENTS.md
 ```
 
-If `~/.codex/AGENTS.md` already contains user-wide instructions, merge `.codex/AGENTS.md` into it instead of overwriting the file.
+Install the supplied routing instructions only when `~/.codex/AGENTS.md` does not already exist:
 
-To keep the user-wide files synchronized with this repository, use symlinks from a local clone:
+```bash
+if [ -e "$HOME/.codex/AGENTS.md" ] || [ -L "$HOME/.codex/AGENTS.md" ]; then
+  printf '%s\n' 'Keep the existing ~/.codex/AGENTS.md and merge the Model routing section from .codex/AGENTS.md manually.'
+else
+  cp .codex/AGENTS.md "$HOME/.codex/AGENTS.md"
+fi
+```
+
+Do not replace an existing file or symlink until its current instructions have been preserved in a merged `~/.codex/AGENTS.md`.
+
+To keep the agent definitions synchronized with this repository, use symlinks from a local clone:
 
 ```bash
 repo_root="$(git rev-parse --show-toplevel)"
 mkdir -p ~/.codex/agents
-ln -sfn "$repo_root/.codex/AGENTS.md" ~/.codex/AGENTS.md
 
 for file in "$repo_root"/.codex/agents/*.toml; do
   ln -sfn "$file" "$HOME/.codex/agents/$(basename "$file")"
 done
+```
+
+Link the routing instructions only when no global `AGENTS.md` exists:
+
+```bash
+if [ -e "$HOME/.codex/AGENTS.md" ] || [ -L "$HOME/.codex/AGENTS.md" ]; then
+  printf '%s\n' 'Keep the existing ~/.codex/AGENTS.md and merge the Model routing section from the repository file manually.'
+else
+  ln -s "$repo_root/.codex/AGENTS.md" "$HOME/.codex/AGENTS.md"
+fi
 ```
 
 Start a new Codex session after installing or updating the files.

--- a/.codex/agents/README.md
+++ b/.codex/agents/README.md
@@ -2,12 +2,12 @@
 
 These project-scoped agents separate high-quality planning and advice from implementation.
 
-| Agent | Model | Access | Purpose |
-| --- | --- | --- | --- |
-| `planner_sol` | `gpt-5.6-sol` | Read-only | Produce a decision-complete implementation plan and select an executor |
-| `advisor_sol` | `gpt-5.6-sol` | Read-only | Provide architectural or technical advice without implementation |
-| `worker_terra` | `gpt-5.6-terra` | Workspace write | Implement non-trivial approved plans |
-| `worker_luna` | `gpt-5.6-luna` | Workspace write | Implement narrow, deterministic, mechanically verifiable plans |
+| Agent          | Model           | Access          | Purpose                                                                |
+| -------------- | --------------- | --------------- | ---------------------------------------------------------------------- |
+| `planner_sol`  | `gpt-5.6-sol`   | Read-only       | Produce a decision-complete implementation plan and select an executor |
+| `advisor_sol`  | `gpt-5.6-sol`   | Read-only       | Provide architectural or technical advice without implementation       |
+| `worker_terra` | `gpt-5.6-terra` | Workspace write | Implement non-trivial approved plans                                   |
+| `worker_luna`  | `gpt-5.6-luna`  | Workspace write | Implement narrow, deterministic, mechanically verifiable plans         |
 
 ## Usage
 

--- a/.codex/agents/README.md
+++ b/.codex/agents/README.md
@@ -32,7 +32,18 @@ To copy the agent definitions and routing instructions for every Codex project:
 ```bash
 codex_home="${CODEX_HOME:-$HOME/.codex}"
 mkdir -p "$codex_home/agents"
-cp .codex/agents/*.toml "$codex_home/agents/"
+
+for file in .codex/agents/*.toml; do
+  destination="$codex_home/agents/$(basename "$file")"
+  if [ -e "$destination" ] || [ -L "$destination" ]; then
+    printf 'Keep the existing %s and merge, back up, or remove it before installing this definition.\n' "$destination" >&2
+    exit 1
+  fi
+done
+
+for file in .codex/agents/*.toml; do
+  cp "$file" "$codex_home/agents/$(basename "$file")"
+done
 
 if [ -e "$codex_home/AGENTS.override.md" ] || [ -L "$codex_home/AGENTS.override.md" ]; then
   printf 'Keep the existing %s and merge the Model routing section from .codex/AGENTS.md into that active override manually.\n' "$codex_home/AGENTS.override.md"
@@ -42,6 +53,8 @@ else
   cp .codex/AGENTS.md "$codex_home/AGENTS.md"
 fi
 ```
+
+The agent preflight stops before copying any definitions when a same-named file or symlink already exists. Preserve the existing definition and merge it manually, or back it up and remove it before rerunning the installation.
 
 Codex prefers a non-empty `AGENTS.override.md` over `AGENTS.md` in its home directory. If an override exists, merge the routing section into that file or remove it only after preserving its instructions. Do not replace either existing file or symlink until its current instructions have been preserved.
 
@@ -53,7 +66,15 @@ repo_root="$(git rev-parse --show-toplevel)"
 mkdir -p "$codex_home/agents"
 
 for file in "$repo_root"/.codex/agents/*.toml; do
-  ln -sfn "$file" "$codex_home/agents/$(basename "$file")"
+  destination="$codex_home/agents/$(basename "$file")"
+  if [ -e "$destination" ] || [ -L "$destination" ]; then
+    printf 'Keep the existing %s and merge, back up, or remove it before installing this symlink.\n' "$destination" >&2
+    exit 1
+  fi
+done
+
+for file in "$repo_root"/.codex/agents/*.toml; do
+  ln -s "$file" "$codex_home/agents/$(basename "$file")"
 done
 
 if [ -e "$codex_home/AGENTS.override.md" ] || [ -L "$codex_home/AGENTS.override.md" ]; then
@@ -64,6 +85,8 @@ else
   ln -s "$repo_root/.codex/AGENTS.md" "$codex_home/AGENTS.md"
 fi
 ```
+
+The symlink preflight likewise stops before creating any links when a destination already exists.
 
 Start a new Codex session after installing or updating the files.
 
@@ -102,6 +125,8 @@ Use advisor_sol to evaluate this design. Return advice only and do not modify fi
 ```
 
 ## Routing policy
+
+The routing policy applies only to the root or main agent. Named custom agents follow their agent-specific instructions and must not spawn or delegate to another subagent.
 
 Use `worker_luna` only for localized, low-risk changes with explicit scope and mechanical validation. Use `worker_terra` when the change requires diagnosis, non-trivial reasoning, cross-cutting edits, or adaptation to repository state.
 

--- a/.codex/agents/README.md
+++ b/.codex/agents/README.md
@@ -25,47 +25,43 @@ A read-only parent prevents implementation workers from writing. A workspace-wri
 
 ## User-wide installation
 
-The files in this repository are project-scoped by default. To make the agent definitions available in every Codex project, copy them to `~/.codex/agents/`:
+The files in this repository are project-scoped by default. Codex uses `$CODEX_HOME` as its home directory when set and otherwise defaults to `$HOME/.codex`.
+
+To copy the agent definitions and routing instructions for every Codex project:
 
 ```bash
-mkdir -p ~/.codex/agents
-cp .codex/agents/*.toml ~/.codex/agents/
-```
+codex_home="${CODEX_HOME:-$HOME/.codex}"
+mkdir -p "$codex_home/agents"
+cp .codex/agents/*.toml "$codex_home/agents/"
 
-Install the supplied routing instructions only when neither global instruction file exists:
-
-```bash
-if [ -e "$HOME/.codex/AGENTS.override.md" ] || [ -L "$HOME/.codex/AGENTS.override.md" ]; then
-  printf '%s\n' 'Keep the existing ~/.codex/AGENTS.override.md and merge the Model routing section from .codex/AGENTS.md into that active override manually.'
-elif [ -e "$HOME/.codex/AGENTS.md" ] || [ -L "$HOME/.codex/AGENTS.md" ]; then
-  printf '%s\n' 'Keep the existing ~/.codex/AGENTS.md and merge the Model routing section from .codex/AGENTS.md manually.'
+if [ -e "$codex_home/AGENTS.override.md" ] || [ -L "$codex_home/AGENTS.override.md" ]; then
+  printf 'Keep the existing %s and merge the Model routing section from .codex/AGENTS.md into that active override manually.\n' "$codex_home/AGENTS.override.md"
+elif [ -e "$codex_home/AGENTS.md" ] || [ -L "$codex_home/AGENTS.md" ]; then
+  printf 'Keep the existing %s and merge the Model routing section from .codex/AGENTS.md manually.\n' "$codex_home/AGENTS.md"
 else
-  cp .codex/AGENTS.md "$HOME/.codex/AGENTS.md"
+  cp .codex/AGENTS.md "$codex_home/AGENTS.md"
 fi
 ```
 
-Codex prefers a non-empty `~/.codex/AGENTS.override.md` over `~/.codex/AGENTS.md`. If an override exists, merge the routing section into that file or remove it only after preserving its instructions. Do not replace either existing file or symlink until its current instructions have been preserved.
+Codex prefers a non-empty `AGENTS.override.md` over `AGENTS.md` in its home directory. If an override exists, merge the routing section into that file or remove it only after preserving its instructions. Do not replace either existing file or symlink until its current instructions have been preserved.
 
 To keep the agent definitions synchronized with this repository, use symlinks from a local clone:
 
 ```bash
+codex_home="${CODEX_HOME:-$HOME/.codex}"
 repo_root="$(git rev-parse --show-toplevel)"
-mkdir -p ~/.codex/agents
+mkdir -p "$codex_home/agents"
 
 for file in "$repo_root"/.codex/agents/*.toml; do
-  ln -sfn "$file" "$HOME/.codex/agents/$(basename "$file")"
+  ln -sfn "$file" "$codex_home/agents/$(basename "$file")"
 done
-```
 
-Link the routing instructions only when neither global instruction file exists:
-
-```bash
-if [ -e "$HOME/.codex/AGENTS.override.md" ] || [ -L "$HOME/.codex/AGENTS.override.md" ]; then
-  printf '%s\n' 'Keep the existing ~/.codex/AGENTS.override.md and merge the Model routing section from the repository file into that active override manually.'
-elif [ -e "$HOME/.codex/AGENTS.md" ] || [ -L "$HOME/.codex/AGENTS.md" ]; then
-  printf '%s\n' 'Keep the existing ~/.codex/AGENTS.md and merge the Model routing section from the repository file manually.'
+if [ -e "$codex_home/AGENTS.override.md" ] || [ -L "$codex_home/AGENTS.override.md" ]; then
+  printf 'Keep the existing %s and merge the Model routing section from the repository file into that active override manually.\n' "$codex_home/AGENTS.override.md"
+elif [ -e "$codex_home/AGENTS.md" ] || [ -L "$codex_home/AGENTS.md" ]; then
+  printf 'Keep the existing %s and merge the Model routing section from the repository file manually.\n' "$codex_home/AGENTS.md"
 else
-  ln -s "$repo_root/.codex/AGENTS.md" "$HOME/.codex/AGENTS.md"
+  ln -s "$repo_root/.codex/AGENTS.md" "$codex_home/AGENTS.md"
 fi
 ```
 

--- a/.codex/agents/README.md
+++ b/.codex/agents/README.md
@@ -23,6 +23,32 @@ Use these parent permission modes:
 
 A read-only parent prevents implementation workers from writing. A workspace-write parent can grant write access to planning agents despite their configured defaults.
 
+## User-wide installation
+
+The files in this repository are project-scoped by default. To make the agents and routing policy available in every Codex project, copy the agent definitions to `~/.codex/agents/` and the supplied routing instructions to `~/.codex/AGENTS.md`:
+
+```bash
+mkdir -p ~/.codex/agents
+cp .codex/agents/*.toml ~/.codex/agents/
+cp .codex/AGENTS.md ~/.codex/AGENTS.md
+```
+
+If `~/.codex/AGENTS.md` already contains user-wide instructions, merge `.codex/AGENTS.md` into it instead of overwriting the file.
+
+To keep the user-wide files synchronized with this repository, use symlinks from a local clone:
+
+```bash
+repo_root="$(git rev-parse --show-toplevel)"
+mkdir -p ~/.codex/agents
+ln -sfn "$repo_root/.codex/AGENTS.md" ~/.codex/AGENTS.md
+
+for file in "$repo_root"/.codex/agents/*.toml; do
+  ln -sfn "$file" "$HOME/.codex/agents/$(basename "$file")"
+done
+```
+
+Start a new Codex session after installing or updating the files.
+
 ## Usage
 
 Ask Codex to delegate explicitly by agent name.

--- a/.codex/agents/README.md
+++ b/.codex/agents/README.md
@@ -2,6 +2,8 @@
 
 These project-scoped agents separate high-quality planning and advice from implementation. Current Codex releases discover each standalone TOML file under `.codex/agents/` automatically; no per-agent registration in `.codex/config.toml` is required.
 
+The invocation examples target local Codex app, CLI, and IDE sessions. Tool-backed or programmatic Codex integrations may not expose named project agents; verify runtime support before relying on these definitions. See [openai/codex#15250](https://github.com/openai/codex/issues/15250).
+
 | Agent          | Model           | Configured sandbox | Purpose                                                                |
 | -------------- | --------------- | ------------------ | ---------------------------------------------------------------------- |
 | `planner_sol`  | `gpt-5.6-sol`   | Read-only          | Produce a decision-complete implementation plan and select an executor |

--- a/.codex/agents/README.md
+++ b/.codex/agents/README.md
@@ -32,17 +32,19 @@ mkdir -p ~/.codex/agents
 cp .codex/agents/*.toml ~/.codex/agents/
 ```
 
-Install the supplied routing instructions only when `~/.codex/AGENTS.md` does not already exist:
+Install the supplied routing instructions only when neither global instruction file exists:
 
 ```bash
-if [ -e "$HOME/.codex/AGENTS.md" ] || [ -L "$HOME/.codex/AGENTS.md" ]; then
+if [ -e "$HOME/.codex/AGENTS.override.md" ] || [ -L "$HOME/.codex/AGENTS.override.md" ]; then
+  printf '%s\n' 'Keep the existing ~/.codex/AGENTS.override.md and merge the Model routing section from .codex/AGENTS.md into that active override manually.'
+elif [ -e "$HOME/.codex/AGENTS.md" ] || [ -L "$HOME/.codex/AGENTS.md" ]; then
   printf '%s\n' 'Keep the existing ~/.codex/AGENTS.md and merge the Model routing section from .codex/AGENTS.md manually.'
 else
   cp .codex/AGENTS.md "$HOME/.codex/AGENTS.md"
 fi
 ```
 
-Do not replace an existing file or symlink until its current instructions have been preserved in a merged `~/.codex/AGENTS.md`.
+Codex prefers a non-empty `~/.codex/AGENTS.override.md` over `~/.codex/AGENTS.md`. If an override exists, merge the routing section into that file or remove it only after preserving its instructions. Do not replace either existing file or symlink until its current instructions have been preserved.
 
 To keep the agent definitions synchronized with this repository, use symlinks from a local clone:
 
@@ -55,10 +57,12 @@ for file in "$repo_root"/.codex/agents/*.toml; do
 done
 ```
 
-Link the routing instructions only when no global `AGENTS.md` exists:
+Link the routing instructions only when neither global instruction file exists:
 
 ```bash
-if [ -e "$HOME/.codex/AGENTS.md" ] || [ -L "$HOME/.codex/AGENTS.md" ]; then
+if [ -e "$HOME/.codex/AGENTS.override.md" ] || [ -L "$HOME/.codex/AGENTS.override.md" ]; then
+  printf '%s\n' 'Keep the existing ~/.codex/AGENTS.override.md and merge the Model routing section from the repository file into that active override manually.'
+elif [ -e "$HOME/.codex/AGENTS.md" ] || [ -L "$HOME/.codex/AGENTS.md" ]; then
   printf '%s\n' 'Keep the existing ~/.codex/AGENTS.md and merge the Model routing section from the repository file manually.'
 else
   ln -s "$repo_root/.codex/AGENTS.md" "$HOME/.codex/AGENTS.md"

--- a/.codex/agents/README.md
+++ b/.codex/agents/README.md
@@ -1,0 +1,44 @@
+# Codex custom subagents
+
+These project-scoped agents separate high-quality planning and advice from implementation.
+
+| Agent | Model | Access | Purpose |
+| --- | --- | --- | --- |
+| `planner_sol` | `gpt-5.6-sol` | Read-only | Produce a decision-complete implementation plan and select an executor |
+| `advisor_sol` | `gpt-5.6-sol` | Read-only | Provide architectural or technical advice without implementation |
+| `worker_terra` | `gpt-5.6-terra` | Workspace write | Implement non-trivial approved plans |
+| `worker_luna` | `gpt-5.6-luna` | Workspace write | Implement narrow, deterministic, mechanically verifiable plans |
+
+## Usage
+
+Ask Codex to delegate explicitly by agent name.
+
+### Plan and implement
+
+```text
+Use planner_sol to plan this task. After the plan is complete, delegate implementation to the recommended worker_terra or worker_luna agent. Use only one write-capable worker.
+```
+
+For a human approval gate, split the workflow into two turns:
+
+```text
+Use planner_sol to produce the implementation plan only. Do not modify files.
+```
+
+After reviewing the plan:
+
+```text
+Implement the approved plan with worker_terra.
+```
+
+### Advice only
+
+```text
+Use advisor_sol to evaluate this design. Return advice only and do not modify files.
+```
+
+## Routing policy
+
+Use `worker_luna` only for localized, low-risk changes with explicit scope and mechanical validation. Use `worker_terra` when the change requires diagnosis, non-trivial reasoning, cross-cutting edits, or adaptation to repository state.
+
+If an implementation agent encounters an unplanned architectural, security, compatibility, or data-model decision, return control to `planner_sol` or `advisor_sol` instead of silently expanding the plan.

--- a/.codex/agents/README.md
+++ b/.codex/agents/README.md
@@ -1,37 +1,55 @@
 # Codex custom subagents
 
-These project-scoped agents separate high-quality planning and advice from implementation.
+These project-scoped agents separate high-quality planning and advice from implementation. Current Codex releases discover each standalone TOML file under `.codex/agents/` automatically; no per-agent registration in `.codex/config.toml` is required.
 
-| Agent          | Model           | Access          | Purpose                                                                |
-| -------------- | --------------- | --------------- | ---------------------------------------------------------------------- |
-| `planner_sol`  | `gpt-5.6-sol`   | Read-only       | Produce a decision-complete implementation plan and select an executor |
-| `advisor_sol`  | `gpt-5.6-sol`   | Read-only       | Provide architectural or technical advice without implementation       |
-| `worker_terra` | `gpt-5.6-terra` | Workspace write | Implement non-trivial approved plans                                   |
-| `worker_luna`  | `gpt-5.6-luna`  | Workspace write | Implement narrow, deterministic, mechanically verifiable plans         |
+| Agent          | Model           | Configured sandbox | Purpose                                                                |
+| -------------- | --------------- | ------------------ | ---------------------------------------------------------------------- |
+| `planner_sol`  | `gpt-5.6-sol`   | Read-only          | Produce a decision-complete implementation plan and select an executor |
+| `advisor_sol`  | `gpt-5.6-sol`   | Read-only          | Provide architectural or technical advice without implementation       |
+| `worker_terra` | `gpt-5.6-terra` | Workspace write    | Implement non-trivial approved plans                                   |
+| `worker_luna`  | `gpt-5.6-luna`  | Workspace write    | Implement narrow, deterministic, mechanically verifiable plans         |
+
+## Permission model
+
+The sandbox values above are agent-file defaults, not immutable per-agent boundaries. A spawned agent inherits the parent turn's live permission mode, and runtime overrides such as `/permissions` or `--yolo` take precedence over the TOML defaults.
+
+Use these parent permission modes:
+
+- Planning or advice only: start the parent turn in read-only mode.
+- Implementation: start a separate parent turn in workspace-write mode.
+- One-turn planning and implementation: use workspace-write mode, but understand that the planner's read-only behavior is instruction-enforced rather than sandbox-enforced.
+
+A read-only parent prevents implementation workers from writing. A workspace-write parent can grant write access to planning agents despite their configured defaults.
 
 ## Usage
 
 Ask Codex to delegate explicitly by agent name.
 
-### Plan and implement
+### Plan and implement in one turn
+
+Start the parent turn in workspace-write mode. This convenience workflow relies on the planner instructions to avoid edits:
 
 ```text
-Use planner_sol to plan this task. After the plan is complete, delegate implementation to the recommended worker_terra or worker_luna agent. Use only one write-capable worker.
+Use planner_sol to plan this task. After the plan is complete, delegate implementation to the recommended worker_terra or worker_luna agent. Use only one active write-capable worker at a time, and do not run workers concurrently.
 ```
 
-For a human approval gate, split the workflow into two turns:
+### Approval-gated workflow
+
+Start the planning turn in read-only mode:
 
 ```text
 Use planner_sol to produce the implementation plan only. Do not modify files.
 ```
 
-After reviewing the plan:
+After reviewing the plan, start a separate parent turn in workspace-write mode:
 
 ```text
 Implement the approved plan with worker_terra.
 ```
 
 ### Advice only
+
+Start the parent turn in read-only mode:
 
 ```text
 Use advisor_sol to evaluate this design. Return advice only and do not modify files.
@@ -40,5 +58,7 @@ Use advisor_sol to evaluate this design. Return advice only and do not modify fi
 ## Routing policy
 
 Use `worker_luna` only for localized, low-risk changes with explicit scope and mechanical validation. Use `worker_terra` when the change requires diagnosis, non-trivial reasoning, cross-cutting edits, or adaptation to repository state.
+
+Use only one active write-capable worker at a time. A sequential Luna-to-Terra handoff is allowed only after Luna has stopped, reported every partial edit, and returned control to the parent. The parent must review that state before starting Terra; workers must not spawn or delegate to another write-capable worker themselves.
 
 If an implementation agent encounters an unplanned architectural, security, compatibility, or data-model decision, return control to `planner_sol` or `advisor_sol` instead of silently expanding the plan.

--- a/.codex/agents/advisor-sol.toml
+++ b/.codex/agents/advisor-sol.toml
@@ -1,0 +1,19 @@
+name = "advisor_sol"
+description = "Provide read-only architectural and technical advice with Sol."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "xhigh"
+sandbox_mode = "read-only"
+developer_instructions = """
+Act as a read-only technical advisor.
+
+Inspect the repository and relevant evidence when useful, but do not modify files, create commits, or transition into implementation. Give a clear recommendation rather than an unranked list of possibilities.
+
+Return:
+1. Recommended decision
+2. Supporting rationale and evidence
+3. Material alternatives and why they rank lower
+4. Trade-offs, risks, and operational implications
+5. Validation method or next decision point
+
+Separate verified facts from assumptions. State uncertainty explicitly. Do not implement the recommendation unless a later request explicitly starts an implementation phase.
+"""

--- a/.codex/agents/planner-sol.toml
+++ b/.codex/agents/planner-sol.toml
@@ -1,0 +1,23 @@
+name = "planner_sol"
+description = "Create an implementation plan with Sol before any repository changes."
+model = "gpt-5.6-sol"
+model_reasoning_effort = "xhigh"
+sandbox_mode = "read-only"
+developer_instructions = """
+Act as the planning phase for software-engineering work.
+
+Inspect the repository and its governing instructions, but do not modify files or run destructive commands. Produce a decision-complete plan that an implementation agent can execute without repeating the architectural analysis.
+
+Return:
+1. Objective and non-goals
+2. Relevant repository constraints and assumptions
+3. Affected files and execution paths
+4. Ordered implementation steps
+5. Validation and acceptance checks
+6. Risks, compatibility concerns, and rollback considerations
+7. Recommended executor: worker_terra or worker_luna
+
+Recommend worker_luna only when the task is narrow, deterministic, low risk, and mechanically verifiable. Recommend worker_terra for all other implementation work.
+
+Do not begin implementation. When material requirements are unresolved, identify the smallest blocking question instead of inventing a requirement.
+"""

--- a/.codex/agents/worker-luna.toml
+++ b/.codex/agents/worker-luna.toml
@@ -1,0 +1,17 @@
+name = "worker_luna"
+description = "Implement narrow deterministic plans with Luna and mechanical validation."
+model = "gpt-5.6-luna"
+model_reasoning_effort = "medium"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Act as a fast implementation agent for narrow, deterministic, low-risk changes.
+
+Proceed only when the supplied plan has explicit scope, affected files, and mechanical acceptance checks. Implement exactly that scope and run the specified validation.
+
+Do not make architectural decisions, broaden the task, perform data migrations, change authentication or authorization behavior, or resolve ambiguous requirements. If the task is broader than a localized edit, validation is unclear, failures require diagnosis, or the plan no longer matches the repository state, stop and recommend worker_terra.
+
+Report:
+1. Files changed
+2. Validation commands and results
+3. Any reason the task should be escalated to worker_terra
+"""

--- a/.codex/agents/worker-luna.toml
+++ b/.codex/agents/worker-luna.toml
@@ -6,12 +6,15 @@ sandbox_mode = "workspace-write"
 developer_instructions = """
 Act as a fast implementation agent for narrow, deterministic, low-risk changes.
 
-Proceed only when the supplied plan has explicit scope, affected files, and mechanical acceptance checks. Implement exactly that scope and run the specified validation.
+Before editing, perform a suitability check. Proceed only when the supplied plan has explicit scope, affected files, mechanical acceptance checks, and no unresolved architectural, security, compatibility, data-model, authentication, authorization, or migration decisions. If any condition fails, do not modify files; return control to the parent and recommend worker_terra.
 
-Do not make architectural decisions, broaden the task, perform data migrations, change authentication or authorization behavior, or resolve ambiguous requirements. If the task is broader than a localized edit, validation is unclear, failures require diagnosis, or the plan no longer matches the repository state, stop and recommend worker_terra.
+Implement exactly the approved scope and run the specified validation. Do not broaden the task or make unplanned design decisions.
+
+If new evidence after editing makes the task unsuitable for Luna, stop editing immediately. Do not spawn or delegate to worker_terra. Report every partial change and the exact escalation reason, then return control to the parent for a reviewed, sequential handoff. Do not claim completion.
 
 Report:
-1. Files changed
-2. Validation commands and results
-3. Any reason the task should be escalated to worker_terra
+1. Pre-edit suitability decision
+2. Files changed, including any partial changes
+3. Validation commands and results
+4. Escalation reason and handoff state, when applicable
 """

--- a/.codex/agents/worker-terra.toml
+++ b/.codex/agents/worker-terra.toml
@@ -1,0 +1,18 @@
+name = "worker_terra"
+description = "Implement approved non-trivial plans with Terra and validate the result."
+model = "gpt-5.6-terra"
+model_reasoning_effort = "high"
+sandbox_mode = "workspace-write"
+developer_instructions = """
+Act as the default implementation agent for approved plans.
+
+Read the repository instructions and current state before editing. Implement the supplied plan with the smallest coherent change set, preserve unrelated behavior, and run the most relevant available validation.
+
+You may make minor tactical adjustments required by the repository state, but do not silently redesign the architecture or expand scope. If implementation requires a material security, compatibility, data-model, or architectural decision not covered by the plan, stop and request replanning by planner_sol or advice from advisor_sol.
+
+Report:
+1. Files changed and key implementation decisions
+2. Validation commands and results
+3. Any deviations from the plan and why
+4. Remaining risks or follow-up work
+"""

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,6 +4,24 @@
 
 This is a single-source skill library shared across AI coding runtimes. The `skills/` directory is the authoritative source of truth; runtime-specific directories reference it via symlinks.
 
+## Model routing
+
+Use the main agent directly for simple questions and narrow, deterministic edits.
+
+For non-trivial implementation tasks:
+
+1. Spawn `planner_sol` before modifying files.
+2. Wait for the complete plan and preserve its constraints and acceptance checks.
+3. Start exactly one implementation agent:
+   - Use `worker_luna` for localized, low-risk changes with explicit scope and mechanical validation.
+   - Use `worker_terra` for diagnosis, cross-cutting changes, ambiguity, or non-trivial implementation.
+4. If implementation encounters an architectural, security, compatibility, or data-model decision not covered by the plan, return control to `planner_sol` or `advisor_sol`.
+5. Do not run write-capable workers concurrently. A sequential Luna-to-Terra handoff is allowed only after Luna has stopped and reported all partial edits.
+
+For architecture, design evaluation, or technical advice without implementation, spawn `advisor_sol` and keep the work read-only.
+
+Do not spawn a subagent when the main agent can complete the task safely and efficiently without delegation.
+
 ## SKILL.md Frontmatter
 
 Each `SKILL.md` uses YAML frontmatter:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -35,3 +35,34 @@ description: <one-line description used for skill triggering>
 allowed-tools: Bash, Read, Write, ... # tools the skill may use
 ---
 ```
+
+## Adding or Modifying Skills
+
+1. Create or edit `skills/<skill-name>/SKILL.md` — this is the canonical skill definition.
+2. Claude Code picks up the skill automatically via `.claude/skills -> ../skills`. For non-Claude runtimes,
+   add a per-skill symlink: `ln -s ../../skills/<skill-name> .agents/skills/<skill-name>`.
+3. Keep `description` in the frontmatter precise — it controls when the skill auto-triggers in Claude Code.
+
+## Autonomous and Scheduled Use
+
+Do not duplicate skill instructions into separate routine files unless a runtime truly requires a self-contained prompt. Prefer invoking the canonical skill under `skills/` and passing schedule, PR, branch, or CI context from the runtime configuration.
+
+For autonomous PR review, `skills/pr-review/SKILL.md` is the source of truth. It defines the GitHub posting contract used by CI, GitHub Actions, Claude Code Routines, and other automated review contexts.
+
+## Local QA
+
+Before committing, run the following checks:
+
+| Check             | Command                          |
+| ----------------- | -------------------------------- |
+| Format Markdown   | `npx -y prettier -w './**/*.md'` |
+| Lint Python       | `uv run ruff check`              |
+| Type-check Python | `uv run pyright`                 |
+| Run tests         | `uv run pytest`                  |
+
+## Commit & Pull Request Guidelines
+
+- Format Markdown files using `npx -y prettier -w './**/*.md'` before committing.
+- Keep PRs focused and include: concise summary, affected workflow paths, linked issue/context, and regenerated `README.md` when workflow inventory changes.
+- Branch names use appropriate prefixes on creation (e.g., `feature/...`, `bugfix/...`, `refactor/...`, `docs/...`, `chore/...`).
+- When instructed to create a PR, create it as a draft with appropriate labels by default.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,8 @@ This is a single-source skill library shared across AI coding runtimes. The `ski
 
 ## Model routing
 
+This section applies only to the root or main agent that receives the user's task. Named custom agents (`planner_sol`, `advisor_sol`, `worker_terra`, and `worker_luna`) must ignore this section, follow their agent-specific instructions, and must not spawn or delegate to another subagent.
+
 Use the main agent directly for simple questions and narrow, deterministic edits.
 
 For non-trivial implementation tasks:
@@ -33,34 +35,3 @@ description: <one-line description used for skill triggering>
 allowed-tools: Bash, Read, Write, ... # tools the skill may use
 ---
 ```
-
-## Adding or Modifying Skills
-
-1. Create or edit `skills/<skill-name>/SKILL.md` — this is the canonical skill definition.
-2. Claude Code picks up the skill automatically via `.claude/skills -> ../skills`. For non-Claude runtimes,
-   add a per-skill symlink: `ln -s ../../skills/<skill-name> .agents/skills/<skill-name>`.
-3. Keep `description` in the frontmatter precise — it controls when the skill auto-triggers in Claude Code.
-
-## Autonomous and Scheduled Use
-
-Do not duplicate skill instructions into separate routine files unless a runtime truly requires a self-contained prompt. Prefer invoking the canonical skill under `skills/` and passing schedule, PR, branch, or CI context from the runtime configuration.
-
-For autonomous PR review, `skills/pr-review/SKILL.md` is the source of truth. It defines the GitHub posting contract used by CI, GitHub Actions, Claude Code Routines, and other automated review contexts.
-
-## Local QA
-
-Before committing, run the following checks:
-
-| Check             | Command                          |
-| ----------------- | -------------------------------- |
-| Format Markdown   | `npx -y prettier -w './**/*.md'` |
-| Lint Python       | `uv run ruff check`              |
-| Type-check Python | `uv run pyright`                 |
-| Run tests         | `uv run pytest`                  |
-
-## Commit & Pull Request Guidelines
-
-- Format Markdown files using `npx -y prettier -w './**/*.md'` before committing.
-- Keep PRs focused and include: concise summary, affected workflow paths, linked issue/context, and regenerated `README.md` when workflow inventory changes.
-- Branch names use appropriate prefixes on creation (e.g., `feature/...`, `bugfix/...`, `refactor/...`, `docs/...`, `chore/...`).
-- When instructed to create a PR, create it as a draft with appropriate labels by default.

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Each skill directory contains a `SKILL.md` that documents prerequisites and invo
 2. Pick a runtime and explore the relevant integration:
    - **Claude Code / Claude Code Routines:** `.claude/skills -> ../skills` (symlink exposing all skills)
    - **Codex CLI skills:** `.agents/skills/` (per-skill symlinks into `skills/`)
-   - **Codex CLI custom subagents:** `.codex/agents/`
+   - **Codex CLI custom subagents:** `.codex/agents/` (project-scoped definitions discovered automatically by current Codex releases)
 
 3. Open a skill directory or `.codex/agents/README.md` to learn how to invoke it.
 
@@ -52,14 +52,14 @@ All skills are located in `skills/` and surfaced through shared discovery or run
 
 ## Codex Custom Subagents
 
-Project-scoped agent definitions under `.codex/agents/` separate planning and advice from implementation:
+Project-scoped agent definitions under `.codex/agents/` separate planning and advice from implementation. Codex discovers each standalone TOML file automatically; no per-agent registration in `.codex/config.toml` is required.
 
 - `planner_sol` - Produce decision-complete plans with `gpt-5.6-sol`
 - `advisor_sol` - Provide read-only technical advice with `gpt-5.6-sol`
 - `worker_terra` - Implement non-trivial plans with `gpt-5.6-terra`
 - `worker_luna` - Implement narrow, deterministic plans with `gpt-5.6-luna`
 
-See [.codex/agents/README.md](./.codex/agents/README.md) for routing rules and invocation examples.
+See [.codex/agents/README.md](./.codex/agents/README.md) for routing rules, permission behavior, and invocation examples.
 
 ## Structure
 

--- a/README.md
+++ b/README.md
@@ -16,11 +16,12 @@ Each skill directory contains a `SKILL.md` that documents prerequisites and invo
    git clone git@github.com:dceoy/ai-coding-agent-skills.git
    ```
 
-2. Pick a runtime and explore the skills in `skills/` and the relevant runtime integration:
+2. Pick a runtime and explore the relevant integration:
    - **Claude Code / Claude Code Routines:** `.claude/skills -> ../skills` (symlink exposing all skills)
-   - **Codex CLI / other runtimes:** `.agents/skills/` (per-skill symlinks into `skills/`)
+   - **Codex CLI skills:** `.agents/skills/` (per-skill symlinks into `skills/`)
+   - **Codex CLI custom subagents:** `.codex/agents/`
 
-3. Open a skill directory and read the `SKILL.md` to learn how to invoke it.
+3. Open a skill directory or `.codex/agents/README.md` to learn how to invoke it.
 
 ## Skills
 
@@ -49,6 +50,17 @@ All skills are located in `skills/` and surfaced through shared discovery or run
 - `claude-agent-converter` - Convert Claude Code agents to portable skills
 - `claude-command-converter` - Convert Claude Code commands to portable skills
 
+## Codex Custom Subagents
+
+Project-scoped agent definitions under `.codex/agents/` separate planning and advice from implementation:
+
+- `planner_sol` - Produce decision-complete plans with `gpt-5.6-sol`
+- `advisor_sol` - Provide read-only technical advice with `gpt-5.6-sol`
+- `worker_terra` - Implement non-trivial plans with `gpt-5.6-terra`
+- `worker_luna` - Implement narrow, deterministic plans with `gpt-5.6-luna`
+
+See [.codex/agents/README.md](./.codex/agents/README.md) for routing rules and invocation examples.
+
 ## Structure
 
 ```
@@ -58,6 +70,8 @@ All skills are located in `skills/` and surfaced through shared discovery or run
 │   └── skills/              # Per-skill symlinks into skills/ (other runtimes)
 ├── .claude/
 │   └── skills -> ../skills  # Symlink exposing skills/ to Claude Code runtime
+├── .codex/
+│   └── agents/              # Project-scoped Codex custom subagents
 ├── .github/
 │   └── workflows/           # CI workflows (ci.yml)
 ├── AGENTS.md                # Repository guidelines (source of truth)


### PR DESCRIPTION
## Summary

- add project-scoped Codex custom agents for Sol planning and advisory work
- add Terra and Luna implementation agents with explicit routing and escalation boundaries
- add project-local model routing to the repository-root `AGENTS.md`
- document invocation examples, permission inheritance, approval-gated execution, user-wide installation, and executor selection
- update the root README with the new `.codex/` integration

## Why

This provides a native Codex workflow for separating high-quality planning or advice from lower-cost implementation. The Sol agent files default to read-only, while implementation uses one active Terra or Luna worker at a time. Because spawned agents inherit the parent turn's live permission mode, enforced planning and implementation separation uses distinct read-only and workspace-write parent turns.

## Impact

Local Codex app, CLI, and IDE users can explicitly delegate to:

- `planner_sol` for decision-complete implementation plans
- `advisor_sol` for advice without edits
- `worker_terra` for non-trivial implementation
- `worker_luna` for narrow, deterministic changes

The repository-root `AGENTS.md` applies the routing policy to project-local Codex sessions. `.codex/AGENTS.md` remains a dedicated template for copying or linking the same policy into the user-wide Codex home.

The agent prompts require escalation instead of silently expanding scope when implementation encounters an unplanned architectural, security, compatibility, or data-model decision. Luna performs a pre-edit suitability check and returns partial work to the parent before any sequential Terra handoff.

Tool-backed or programmatic Codex integrations must confirm that their runtime exposes named project agents; the documentation links the current upstream limitation.

## Validation

- parsed all four TOML definitions with Python `tomllib`
- confirmed the configured sandbox defaults and documented parent permission inheritance
- confirmed Luna's pre-edit suitability and parent-reviewed sequential handoff rules
- confirmed project-local routing is present in repository-root `AGENTS.md`
- confirmed `.codex/AGENTS.md` is explicitly documented as the user-wide installation template
- repository test suite not run; changes are configuration and documentation only
