### PR TITLE
Relax Codex named-agent runtime attestation requirements

### DIFF
--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -20,7 +20,7 @@ Use the main agent directly for simple questions and narrow, deterministic edits
 
 For non-trivial implementation tasks:
 
-1. Invoke `planner` in a separate context with effective read-only permission and obtain a decision-complete contract covering objective, scope, interfaces, constraints, and verification. Accept the contract when native dispatch returns the requested planner result unless runtime evidence explicitly reports a fallback, incompatible override, or writable permission.
+1. Invoke `planner` in a separate context with effective read-only permission and obtain a decision-complete contract covering objective, scope, interfaces, constraints, and verification. Accept the contract when native dispatch returns the requested planner result unless runtime evidence explicitly reports a fallback, incompatible override, writable permission, or inherited context contrary to `fork_turns: "none"`.
 2. Resolve material architectural, product, security, compatibility, or data-model decisions before implementation. Do not invent requirements.
 3. Pass the approved contract to a top-level implementation session configured with `model_reasoning_effort = "xhigh"`; otherwise restart with `xhigh` or report `unsupported`. Implement the approved contract directly in that session. Do not delegate implementation to a worker subagent.
 4. Inspect the actual changes, preserve unrelated work, and run the relevant verification from the planner contract.

--- a/.codex/AGENTS.md
+++ b/.codex/AGENTS.md
@@ -8,9 +8,9 @@ This file is the user-wide installation template. Project-local Codex sessions r
 
 Invoke each role with `fork_turns: "none"` and pass its task-specific context explicitly; do not rely on inherited conversation history.
 
-Accept a result only when the runtime provides parent-visible evidence that the requested named definition resolved with its configured role, model, and reasoning effort. Treat missing evidence or a generic-child fallback as `unsupported`.
+Treat the installed agent TOML as the source of truth for the named role, model, reasoning effort, and sandbox defaults. A successful native dispatch to the requested named role is sufficient; the runtime does not need to echo those configuration values back to the parent. Treat the invocation as `unsupported` only when available runtime evidence explicitly shows that native dispatch is unavailable, a generic or different agent was used, or a configured guarantee was overridden incompatibly. Missing runtime telemetry is not evidence of a mismatch.
 
-Implementation is owned by the top-level main agent. Do not delegate implementation to named or generic worker subagents. If native dispatch or a required runtime guarantee is unavailable, report `unsupported` rather than silently omitting, downgrading, or simulating a phase.
+Implementation is owned by the top-level main agent. Do not delegate implementation to named or generic worker subagents. If native dispatch is explicitly unavailable or incompatible with the configured role, report `unsupported` rather than silently omitting, downgrading, or simulating a phase.
 
 ## Model routing
 
@@ -20,14 +20,14 @@ Use the main agent directly for simple questions and narrow, deterministic edits
 
 For non-trivial implementation tasks:
 
-1. Invoke `planner` in a separate context with effective read-only permission and obtain a decision-complete contract covering objective, scope, interfaces, constraints, and verification. Accept the contract only when the runtime attests the named definition, model, reasoning effort, and effective permission; otherwise report `unsupported`.
+1. Invoke `planner` in a separate context with effective read-only permission and obtain a decision-complete contract covering objective, scope, interfaces, constraints, and verification. Accept the contract when native dispatch returns the requested planner result unless runtime evidence explicitly reports a fallback, incompatible override, or writable permission.
 2. Resolve material architectural, product, security, compatibility, or data-model decisions before implementation. Do not invent requirements.
 3. Pass the approved contract to a top-level implementation session configured with `model_reasoning_effort = "xhigh"`; otherwise restart with `xhigh` or report `unsupported`. Implement the approved contract directly in that session. Do not delegate implementation to a worker subagent.
 4. Inspect the actual changes, preserve unrelated work, and run the relevant verification from the planner contract.
-5. Invoke `advisor` in a fresh context with effective read-only permission. Provide the planner contract, actual changed files or diff, implementation decisions, and verification results. If either runtime guarantee cannot be established, report `unsupported` and do not accept a verdict.
-6. Handle the verdict: apply bounded `fix-first` findings in the main agent; for `rethink`, return to `planner` and approve a revised contract before reimplementation; `unsupported` blocks completion. Rerun verification and fresh review after changes. Report completion only after `VERDICT: ship`.
+5. Invoke `advisor` in a fresh context with effective read-only permission. Provide the planner contract, actual changed files or diff, implementation decisions, and verification results. Accept its verdict unless runtime evidence explicitly reports a fallback, incompatible override, writable permission, or inherited context contrary to `fork_turns: "none"`.
+6. Handle the verdict: apply bounded `fix-first` findings in the main agent; for `rethink`, return to `planner` and approve a revised contract before reimplementation; an explicitly justified `unsupported` verdict blocks completion. Rerun verification and fresh review after changes. Report completion only after `VERDICT: ship`.
 
-The planner and advisor TOML files configure `model_reasoning_effort = "xhigh"` and read-only defaults. Runtime overrides must not weaken the final-review requirements above.
+The planner and advisor TOML files configure `model_reasoning_effort = "xhigh"` and read-only defaults. Runtime overrides must not weaken the final-review requirements above, but absence of parent-visible runtime metadata alone must not block execution.
 
 For architecture, design evaluation, or technical advice without implementation, invoke `advisor` and keep the work read-only.
 

--- a/.codex/agents/README.md
+++ b/.codex/agents/README.md
@@ -7,7 +7,7 @@ These project-scoped TOML files define two native read-only Codex roles:
 
 Implementation is performed directly by the top-level main agent. There are no dedicated Luna or Terra worker roles.
 
-Invoke `planner` and `advisor` only through Codex native multi-agent tools. Do not use nested `codex exec`, shell wrappers, copied prompts, generic agents, or simulations. Invoke each role with `fork_turns: "none"` and pass its task-specific context explicitly. Accept results only when the runtime confirms the requested named definition, model, and reasoning effort; otherwise report `unsupported`.
+Invoke `planner` and `advisor` only through Codex native multi-agent tools. Do not use nested `codex exec`, shell wrappers, copied prompts, generic agents, or simulations. Invoke each role with `fork_turns: "none"` and pass its task-specific context explicitly. Treat these TOML definitions as authoritative for the configured role, model, reasoning effort, and sandbox defaults. A successful native dispatch to the requested named role is enough to proceed; do not require the runtime to echo configuration metadata that it may not expose. Report `unsupported` only when available runtime evidence explicitly shows a fallback, incompatible override, writable permission, inherited context contrary to the requested isolation, or unavailable native dispatch.
 
 ## Routing
 
@@ -15,14 +15,14 @@ Use the main agent directly for simple questions and narrow, deterministic edits
 
 For non-trivial implementation:
 
-1. Invoke `planner` in a separate context with effective read-only permission. Accept its contract only when the runtime attests the named definition, model, reasoning effort, and effective permission; otherwise report `unsupported`.
+1. Invoke `planner` in a separate context with effective read-only permission. Accept its contract unless runtime evidence explicitly reports a fallback, incompatible override, or writable permission; missing runtime telemetry alone is not a failure.
 2. Resolve material open decisions and approve the plan.
 3. Pass the approved contract to a top-level implementation session configured with `model_reasoning_effort = "xhigh"`; otherwise restart with `xhigh` or report `unsupported`. Implement the plan directly in that session.
 4. Inspect the actual changes and run the planned verification.
-5. Invoke `advisor` in a fresh context with effective read-only permission, passing the planner contract, changed files or diff, implementation decisions, and verification results. If either runtime guarantee cannot be established, report `unsupported` and do not accept a verdict.
-6. Apply bounded `fix-first` findings in the main agent. For `rethink`, return to `planner` and approve a revised contract before reimplementation. `unsupported` blocks completion. Repeat verification and fresh review until `VERDICT: ship`.
+5. Invoke `advisor` in a fresh context with effective read-only permission, passing the planner contract, changed files or diff, implementation decisions, and verification results. Accept its verdict unless runtime evidence explicitly contradicts the configured role, model, reasoning effort, read-only permission, or fresh-context request.
+6. Apply bounded `fix-first` findings in the main agent. For `rethink`, return to `planner` and approve a revised contract before reimplementation. An explicitly justified `unsupported` verdict blocks completion. Repeat verification and fresh review until `VERDICT: ship`.
 
-The planner and advisor TOMLs configure `model_reasoning_effort = "xhigh"` and read-only defaults. The top-level implementation session must be configured with `model_reasoning_effort = "xhigh"` separately, and runtime overrides must not weaken final-review isolation.
+The planner and advisor TOMLs configure `model_reasoning_effort = "xhigh"` and read-only defaults. The top-level implementation session must be configured with `model_reasoning_effort = "xhigh"` separately, and runtime overrides must not weaken final-review isolation. Absence of parent-visible runtime attestation by itself must not stop the workflow.
 
 ## User-wide installation
 
@@ -62,13 +62,13 @@ Start a fresh Codex session after installation and verify that native `planner` 
 ### Planning and implementation phase
 
 ```text
-Use native planner with fork_turns set to none in a separate effectively read-only context, and supply the task-specific context explicitly. Produce a decision-complete plan for this task. Accept the plan only after confirming the named planner definition, gpt-5.6-sol, xhigh, and effective read-only permission. Resolve any blocking questions, then pass the approved contract to a top-level main-agent session configured with model_reasoning_effort = "xhigh". Do not delegate implementation to worker subagents. Run the planned verification and prepare the planner contract, actual changed files or diff, implementation decisions, and verification results for the mandatory final-review phase below. Do not report completion yet.
+Use native planner with fork_turns set to none in a separate effectively read-only context, and supply the task-specific context explicitly. Produce a decision-complete plan for this task. Treat the installed planner definition as authoritative for gpt-5.6-sol, xhigh, and read-only defaults unless the runtime explicitly reports a fallback or incompatible override. Do not require parent-visible configuration attestation. Resolve any blocking questions, then pass the approved contract to a top-level main-agent session configured with model_reasoning_effort = "xhigh". Do not delegate implementation to worker subagents. Run the planned verification and prepare the planner contract, actual changed files or diff, implementation decisions, and verification results for the mandatory final-review phase below. Do not report completion yet.
 ```
 
 ### Mandatory final review
 
 ```text
-After confirming that the named advisor definition resolved with gpt-5.6-sol and xhigh, use it in a fresh context with effective read-only permission and fork_turns set to none. Review the planner contract, actual changes, implementation decisions, and verification results. Do not modify files. Return VERDICT: ship, fix-first, rethink, or unsupported. Report completion only after VERDICT: ship; apply fix-first findings and rerun verification and review, return rethink findings to planner for a revised approved contract, and treat unsupported as blocking.
+Use native advisor with fork_turns set to none in a fresh effectively read-only context. Treat the installed advisor definition as authoritative for gpt-5.6-sol, xhigh, and read-only defaults unless the runtime explicitly reports a fallback, incompatible override, writable permission, or inherited context. Do not require parent-visible configuration attestation. Review the planner contract, actual changes, implementation decisions, and verification results. Do not modify files. Return VERDICT: ship, fix-first, rethink, or unsupported. Report completion only after VERDICT: ship; apply fix-first findings and rerun verification and review, return rethink findings to planner for a revised approved contract, and treat explicitly justified unsupported as blocking.
 ```
 
 ### Advice only

--- a/.codex/agents/README.md
+++ b/.codex/agents/README.md
@@ -15,14 +15,14 @@ Use the main agent directly for simple questions and narrow, deterministic edits
 
 For non-trivial implementation:
 
-1. Invoke `planner` in a separate context with effective read-only permission. Accept its contract unless runtime evidence explicitly reports a fallback, incompatible override, or writable permission; missing runtime telemetry alone is not a failure.
+1. Invoke `planner` in a separate context with effective read-only permission. Accept its contract unless runtime evidence explicitly reports a fallback, incompatible override, writable permission, or inherited context contrary to `fork_turns: "none"`; missing runtime telemetry alone is not a failure.
 2. Resolve material open decisions and approve the plan.
 3. Pass the approved contract to a top-level implementation session configured with `model_reasoning_effort = "xhigh"`; otherwise restart with `xhigh` or report `unsupported`. Implement the plan directly in that session.
 4. Inspect the actual changes and run the planned verification.
 5. Invoke `advisor` in a fresh context with effective read-only permission, passing the planner contract, changed files or diff, implementation decisions, and verification results. Accept its verdict unless runtime evidence explicitly contradicts the configured role, model, reasoning effort, read-only permission, or fresh-context request.
 6. Apply bounded `fix-first` findings in the main agent. For `rethink`, return to `planner` and approve a revised contract before reimplementation. An explicitly justified `unsupported` verdict blocks completion. Repeat verification and fresh review until `VERDICT: ship`.
 
-The planner and advisor TOMLs configure `model_reasoning_effort = "xhigh"` and read-only defaults. The top-level implementation session must be configured with `model_reasoning_effort = "xhigh"` separately, and runtime overrides must not weaken final-review isolation. Absence of parent-visible runtime attestation by itself must not stop the workflow.
+The planner and advisor TOML files configure `model_reasoning_effort = "xhigh"` and read-only defaults. The top-level implementation session must be configured with `model_reasoning_effort = "xhigh"` separately, and runtime overrides must not weaken final-review isolation. Absence of parent-visible runtime attestation by itself must not stop the workflow.
 
 ## User-wide installation
 
@@ -62,7 +62,7 @@ Start a fresh Codex session after installation and verify that native `planner` 
 ### Planning and implementation phase
 
 ```text
-Use native planner with fork_turns set to none in a separate effectively read-only context, and supply the task-specific context explicitly. Produce a decision-complete plan for this task. Treat the installed planner definition as authoritative for gpt-5.6-sol, xhigh, and read-only defaults unless the runtime explicitly reports a fallback or incompatible override. Do not require parent-visible configuration attestation. Resolve any blocking questions, then pass the approved contract to a top-level main-agent session configured with model_reasoning_effort = "xhigh". Do not delegate implementation to worker subagents. Run the planned verification and prepare the planner contract, actual changed files or diff, implementation decisions, and verification results for the mandatory final-review phase below. Do not report completion yet.
+Use native planner with fork_turns set to none in a separate effectively read-only context, and supply the task-specific context explicitly. Produce a decision-complete plan for this task. Treat the installed planner definition as authoritative for gpt-5.6-sol, xhigh, and read-only defaults unless the runtime explicitly reports a fallback, incompatible override, writable permission, or inherited context contrary to fork_turns set to none. Do not require parent-visible configuration attestation. Resolve any blocking questions, then pass the approved contract to a top-level main-agent session configured with model_reasoning_effort = "xhigh". Do not delegate implementation to worker subagents. Run the planned verification and prepare the planner contract, actual changed files or diff, implementation decisions, and verification results for the mandatory final-review phase below. Do not report completion yet.
 ```
 
 ### Mandatory final review

--- a/.codex/agents/advisor.toml
+++ b/.codex/agents/advisor.toml
@@ -15,7 +15,9 @@ For architecture, design evaluation, or technical advice, return:
 4. Trade-offs, risks, and operational implications
 5. Validation method or next decision point
 
-For a final implementation review, require parent-visible confirmation that the named `advisor` definition resolved with `gpt-5.6-sol` and `xhigh`, plus a fresh context with no inherited implementation history and effective read-only permission. If any requirement is not confirmed, return `VERDICT: unsupported` without reviewing. Otherwise review:
+For a final implementation review, treat this named agent definition as authoritative for the configured `advisor` role, `gpt-5.6-sol`, `xhigh`, and read-only sandbox. A native invocation with `fork_turns: "none"` is sufficient to establish a fresh context unless the runtime explicitly reports otherwise. Do not require the parent runtime to echo or attest configuration metadata that it may not expose. Return `VERDICT: unsupported` only when available runtime evidence explicitly shows that native dispatch is unavailable, a generic or different agent was used, the configured model or reasoning effort was overridden, the effective permission is writable, or the context was inherited contrary to the requested isolation. Missing runtime telemetry is not a failure condition.
+
+Otherwise review:
 - the approved planner contract;
 - the actual changed files or diff;
 - the implementation decisions;
@@ -29,5 +31,5 @@ REASON: <decisive evidence-based reason>
 FINDINGS: <precise file references and required fixes, or none>
 RESIDUAL RISK: <most important remaining risk, or none>
 
-Use `fix-first` for bounded implementation defects, `rethink` when the plan, architecture, requirements, or scope must change, and `unsupported` when the required review isolation or permission cannot be established. Do not implement your own findings.
+Use `fix-first` for bounded implementation defects, `rethink` when the plan, architecture, requirements, or scope must change, and `unsupported` only for an explicit runtime incompatibility described above. Do not implement your own findings.
 """

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -10,9 +10,9 @@ This is a single-source skill library shared across AI coding runtimes. The `ski
 
 Invoke each role with `fork_turns: "none"` and pass its task-specific context explicitly; do not rely on inherited conversation history.
 
-Accept a result only when the runtime provides parent-visible evidence that the requested named definition resolved with its configured role, model, and reasoning effort. Treat missing evidence or a generic-child fallback as `unsupported`.
+Treat the installed agent TOML as the source of truth for the named role, model, reasoning effort, and sandbox defaults. A successful native dispatch to the requested named role is sufficient; the runtime does not need to echo those configuration values back to the parent. Treat the invocation as `unsupported` only when available runtime evidence explicitly shows that native dispatch is unavailable, a generic or different agent was used, or a configured guarantee was overridden incompatibly. Missing runtime telemetry is not evidence of a mismatch.
 
-Implementation is owned by the top-level main agent. Do not delegate implementation to named or generic worker subagents. If native dispatch or a required runtime guarantee is unavailable, report `unsupported` rather than silently omitting, downgrading, or simulating a phase.
+Implementation is owned by the top-level main agent. Do not delegate implementation to named or generic worker subagents. If native dispatch is explicitly unavailable or incompatible with the configured role, report `unsupported` rather than silently omitting, downgrading, or simulating a phase.
 
 ## Model routing
 
@@ -22,14 +22,14 @@ Use the main agent directly for simple questions and narrow, deterministic edits
 
 For non-trivial implementation tasks:
 
-1. Invoke `planner` in a separate context with effective read-only permission and obtain a decision-complete contract covering objective, scope, interfaces, constraints, and verification. Accept the contract only when the runtime attests the named definition, model, reasoning effort, and effective permission; otherwise report `unsupported`.
+1. Invoke `planner` in a separate context with effective read-only permission and obtain a decision-complete contract covering objective, scope, interfaces, constraints, and verification. Accept the contract when native dispatch returns the requested planner result unless runtime evidence explicitly reports a fallback, incompatible override, or writable permission.
 2. Resolve material architectural, product, security, compatibility, or data-model decisions before implementation. Do not invent requirements.
 3. Pass the approved contract to a top-level implementation session configured with `model_reasoning_effort = "xhigh"`; otherwise restart with `xhigh` or report `unsupported`. Implement the approved contract directly in that session. Do not delegate implementation to a worker subagent.
 4. Inspect the actual changes, preserve unrelated work, and run the relevant verification from the planner contract.
-5. Invoke `advisor` in a fresh context with effective read-only permission. Provide the planner contract, actual changed files or diff, implementation decisions, and verification results. If either runtime guarantee cannot be established, report `unsupported` and do not accept a verdict.
-6. Handle the verdict: apply bounded `fix-first` findings in the main agent; for `rethink`, return to `planner` and approve a revised contract before reimplementation; `unsupported` blocks completion. Rerun verification and fresh review after changes. Report completion only after `VERDICT: ship`.
+5. Invoke `advisor` in a fresh context with effective read-only permission. Provide the planner contract, actual changed files or diff, implementation decisions, and verification results. Accept its verdict unless runtime evidence explicitly reports a fallback, incompatible override, writable permission, or inherited context contrary to `fork_turns: "none"`.
+6. Handle the verdict: apply bounded `fix-first` findings in the main agent; for `rethink`, return to `planner` and approve a revised contract before reimplementation; an explicitly justified `unsupported` verdict blocks completion. Rerun verification and fresh review after changes. Report completion only after `VERDICT: ship`.
 
-The planner and advisor TOML files configure `model_reasoning_effort = "xhigh"` and read-only defaults. Runtime overrides must not weaken the final-review requirements above.
+The planner and advisor TOML files configure `model_reasoning_effort = "xhigh"` and read-only defaults. Runtime overrides must not weaken the final-review requirements above, but absence of parent-visible runtime metadata alone must not block execution.
 
 For architecture, design evaluation, or technical advice without implementation, invoke `advisor` and keep the work read-only.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,7 +22,7 @@ Use the main agent directly for simple questions and narrow, deterministic edits
 
 For non-trivial implementation tasks:
 
-1. Invoke `planner` in a separate context with effective read-only permission and obtain a decision-complete contract covering objective, scope, interfaces, constraints, and verification. Accept the contract when native dispatch returns the requested planner result unless runtime evidence explicitly reports a fallback, incompatible override, or writable permission.
+1. Invoke `planner` in a separate context with effective read-only permission and obtain a decision-complete contract covering objective, scope, interfaces, constraints, and verification. Accept the contract when native dispatch returns the requested planner result unless runtime evidence explicitly reports a fallback, incompatible override, writable permission, or inherited context contrary to `fork_turns: "none"`.
 2. Resolve material architectural, product, security, compatibility, or data-model decisions before implementation. Do not invent requirements.
 3. Pass the approved contract to a top-level implementation session configured with `model_reasoning_effort = "xhigh"`; otherwise restart with `xhigh` or report `unsupported`. Implement the approved contract directly in that session. Do not delegate implementation to a worker subagent.
 4. Inspect the actual changes, preserve unrelated work, and run the relevant verification from the planner contract.

--- a/README.md
+++ b/README.md
@@ -59,9 +59,9 @@ Project-scoped definitions under `.codex/agents/` provide two native read-only C
 
 Both roles use `model_reasoning_effort = "xhigh"`. Implementation is performed directly by the top-level main agent; there are no dedicated Luna or Terra worker subagents. The implementation session must be configured with `model_reasoning_effort = "xhigh"` separately.
 
-For non-trivial changes, invoke `planner` and `advisor` with `fork_turns: "none"`, pass each role only the task-specific context it needs, and require effective read-only permission plus named-definition, model, and reasoning attestation. Resolve material decisions before main-agent implementation, run verification, and report completion only after an independent `VERDICT: ship`.
+For non-trivial changes, invoke `planner` and `advisor` with `fork_turns: "none"`, pass each role only the task-specific context it needs, and require effective read-only permission. Treat the checked-in TOML definitions as authoritative for the configured named role, model, reasoning effort, and sandbox defaults; do not require parent-visible runtime configuration attestation. Resolve material decisions before main-agent implementation, run verification, and report completion only after an independent `VERDICT: ship`.
 
-Invoke these roles only through native multi-agent dispatch. If native dispatch or the required runtime guarantees are unavailable, report `unsupported`; do not fall back to nested `codex exec`, shell wrappers, copied prompts, or generic agents.
+Invoke these roles only through native multi-agent dispatch. Report `unsupported` only when native dispatch is unavailable or runtime evidence explicitly shows a fallback, incompatible override, writable permission, or inherited context contrary to the requested isolation; missing runtime telemetry alone is not a failure. Do not fall back to nested `codex exec`, shell wrappers, copied prompts, or generic agents.
 
 See [.codex/agents/README.md](./.codex/agents/README.md) for installation and usage examples.
 


### PR DESCRIPTION
## Summary

- treat the checked-in Codex agent TOMLs as the source of truth for named role, model, reasoning effort, and sandbox defaults
- stop requiring parent-visible runtime metadata that Codex may not expose
- restrict `unsupported` to explicit runtime incompatibilities such as native dispatch failure, fallback to a different/generic agent, incompatible overrides, writable permission, or inherited context
- keep planner/advisor native dispatch, `fork_turns: "none"`, read-only operation, and the mandatory final-review loop intact

## Root cause

The routing policy required positive runtime attestation for the named role, model, `xhigh`, and effective read-only permission. When the runtime did not expose those details, a valid planner result was rejected and advisor returned `VERDICT: unsupported`, which blocked commit/push even without evidence of an actual mismatch.

## Impact

Non-trivial Codex workflows can now continue when runtime configuration telemetry is absent, while still failing closed when the runtime explicitly reports a fallback or incompatible override.

## Validation

- compared the branch against `main`: 1 commit, 4 focused files
- reviewed the generated commit diff to confirm the change is limited to Codex routing/review policy and advisor instructions
- `planner.toml` remains unchanged
